### PR TITLE
Add extended interpolation support to config parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,9 @@ MANIFEST
 /custodia.audit.log
 /secrets.db
 /testlog.txt
+/test_audit.log
+/test_custodia.conf
+/test_log.txt
+/test_mkey.conf
+/test_secrets.db
 

--- a/custodia.conf
+++ b/custodia.conf
@@ -1,3 +1,14 @@
+# This config file supports extended interpolations
+# https://docs.python.org/3/library/configparser.html#configparser.ExtendedInterpolation
+# Environment variables can be references from the ENV section:
+#
+# Example:
+#    [DEFAULT]
+#    cafile = 'path/to/ca.pem'
+#    [global]
+#    tls_cafile = ${DEFAULT:cafile}
+#    server_socket = ${ENV:HOME}/server_socket
+
 [global]
 server_version = "Secret/0.0.7"
 debug = True

--- a/custodia/custodia
+++ b/custodia/custodia
@@ -3,18 +3,21 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
 
 try:
-    from ConfigParser import RawConfigParser
     from urllib import quote as url_escape
 except ImportError:
-    from configparser import RawConfigParser
     from urllib.parse import quote as url_escape
-from custodia.httpd.server import HTTPServer
-from custodia import log
 import importlib
 import logging
 import os
-import six
 import sys
+
+# use https://pypi.python.org/pypi/configparser/ on Python 2
+from configparser import SafeConfigParser, ExtendedInterpolation, DEFAULTSECT
+import six
+
+from custodia.httpd.server import HTTPServer
+from custodia import log
+
 
 logger = logging.getLogger('custodia')
 
@@ -44,16 +47,25 @@ def attach_store(typename, plugins, stores):
 CONFIG_SPECIALS = ['authenticators', 'authorizers', 'consumers', 'stores']
 
 def parse_config(cfgfile):
-    parser = RawConfigParser()
+    parser = SafeConfigParser(interpolation=ExtendedInterpolation())
     parser.optionxform = str
-    files = parser.read(cfgfile)
-    if len(files) == 0:
-        raise IOError("Failed to read config file")
+
+    with open(cfgfile) as f:
+        parser.readfp(f)
 
     config = dict()
     for s in CONFIG_SPECIALS:
         config[s] = dict()
+
+    # add env
+    parser['ENV'] = {
+        k: v.replace('$', '$$') for k, v in os.environ.items()
+        if not set(v).intersection('\r\n\x00')}
+
     for s in parser.sections():
+        if s == 'ENV':
+            # ENV section is only used for interpolation
+            continue
         if s == 'global':
             for opt, val in parser.items(s):
                 if opt in CONFIG_SPECIALS:

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -1,0 +1,84 @@
+###############
+Custodia Config
+###############
+
+Custodia uses a ini-style configuration file with
+`extended interpolation <https://docs.python.org/3/library/configparser.html#configparser.ExtendedInterpolation>`_.
+
+Sections
+========
+
+globals
+-------
+
+server_url [str]
+   * http://hostname:port
+   * http+unix://%2Fpath%2Fto%2Fserver_sock
+
+server_socket [str]
+   Path to :const:`AF_UNIX` socket file.
+
+server_string [str]
+   String to send as HTTP Server string
+
+debug [bool, default=False]
+   enable debugging
+
+
+authenticators
+--------------
+
+Example::
+
+   [auth:header]
+   handler = custodia.httpd.authenticators.SimpleHeaderAuth
+   name = REMOTE_USER
+
+
+authorizers
+-----------
+
+Example::
+
+   [authz:namespaces]
+   handler = custodia.httpd.authorizers.UserNameSpace
+   path = /secrets/
+   store = simple
+
+
+stores
+------
+
+Example::
+
+   [store:simple]
+   handler = custodia.store.sqlite.SqliteStore
+   dburi = /path/to/secrets.db
+   table = secrets
+
+
+consumers
+---------
+
+Example::
+
+   [/]
+   handler = custodia.root.Root
+   store = simple
+
+
+Special sections
+================
+
+DEFAULT
+-------
+
+The :const:`DEFAULT` section contains default values for all sections.
+
+ENV
+---
+
+The :const:`ENV` is populated with all enviroment variables. To reference
+:const:`HOME` variable::
+
+   server_socket = ${ENV:HOME}/server_socket

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,6 +20,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+   config.rst
 
 
 Indices and tables

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ jwcrypto
 six
 python-etcd
 requests
+# extended interpolation is provided by stdlib in Python 3.4+
+configparser; python_version < '3.4'


### PR DESCRIPTION
Custodia's config file now uses features from Python 3's configparser. On
Python 2 the backport package is used.

With extended interpolation it is now possible to reference env vars in
config files, e.g. ${ENV:HOME}.

Signed-off-by: Christian Heimes <cheimes@redhat.com>