### PR TITLE
Fix sign-ness of uid_t/gid_t in SO_PEERCRED

### DIFF
--- a/custodia/httpd/server.py
+++ b/custodia/httpd/server.py
@@ -161,9 +161,11 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
         if self.request.family != socket.AF_UNIX:
             self._creds = None
             return self._creds
+        # pid_t: signed int32, uid_t/gid_t: unsigned int32
+        fmt = 'iII'
         creds = self.request.getsockopt(socket.SOL_SOCKET, SO_PEERCRED,
-                                        struct.calcsize('3i'))
-        pid, uid, gid = struct.unpack('3i', creds)
+                                        struct.calcsize(fmt))
+        pid, uid, gid = struct.unpack(fmt, creds)
         try:
             creds = self.request.getsockopt(socket.SOL_SOCKET, SO_PEERSEC,
                                             SELINUX_CONTEXT_LEN)


### PR DESCRIPTION
uid_t and git_t are uint32_t on all relevant platforms. Custodia used to
treat them as signed ints like pid_t.

The Open Group defines them just as 'integer types'. Major platforms
(Linux, BSD) define them as uint32_t:

http://pubs.opengroup.org/onlinepubs/009696699/basedefs/sys/types.h.html

* nlink_t, uid_t, gid_t, and id_t shall be integer types.
* blksize_t, pid_t, and ssize_t shall be signed integer types.

http://linux.die.net/include/bits/types.h

http://fxr.watson.org/fxr/source/sys/_types.h#L63
typedef __uint32_t      __uid_t;

Signed-off-by: Christian Heimes <cheimes@redhat.com>