### PR TITLE
Python 3: Fix output encoding

### DIFF
--- a/custodia/httpd/server.py
+++ b/custodia/httpd/server.py
@@ -321,12 +321,9 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
                 shutil.copyfileobj(output, self.wfile)
                 output.close()
             elif output is not None:
-                ctype = response.get('headers', {}).get('Content-type',
-                                                        'application/json')
-                if ctype == 'application/octet-stream':
-                    self.wfile.write(bytes(output))
-                else:
-                    self.wfile.write(str(output).encode('utf-8'))
+                if not isinstance(output, six.binary_type):
+                    output = output.encode('utf-8')
+                self.wfile.write(output)
             else:
                 self.close_connection = 1
             self.wfile.flush()


### PR DESCRIPTION
Commit 57686114cfd464bb6b8a2fe6be6d80ea38d43da9 introduced an encoding
bug for Python 3. In Python3 str(b'somebytestr') returns the string
"b'somebytestring'". To fix the issue the output is now converted to
bytes if and only if the handler has returned text. The output wfile
accepts only bytes anyway.

Signed-off-by: Christian Heimes <cheimes@redhat.com>