### PR TITLE
Move serialization into HTTP consumer

### DIFF
--- a/custodia/client.py
+++ b/custodia/client.py
@@ -268,7 +268,7 @@ class CustodiaKEMClient(CustodiaHTTPClient):
         self._kem_unwrap(cname, r.json())
 
     def list_container(self, name):
-        return json_decode(self.get_secret(self.container_name(name)))
+        return self.get_secret(self.container_name(name))
 
     def get_secret(self, name):
         message = self._kem_wrap(name, None)

--- a/custodia/httpd/server.py
+++ b/custodia/httpd/server.py
@@ -319,21 +319,18 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
                 self.send_error(500)
                 self.wfile.flush()
                 return
+
             self.send_response(response.get('code', 200))
             for header, value in six.iteritems(response.get('headers', {})):
                 self.send_header(header, value)
             self.end_headers()
+
             output = response.get('output', None)
             if hasattr(output, 'read'):
                 shutil.copyfileobj(output, self.wfile)
                 output.close()
             elif output is not None:
-                ctype = response.get('headers', {}).get('Content-type',
-                                                        'application/json')
-                if ctype == 'application/octet-stream':
-                    self.wfile.write(bytes(output))
-                else:
-                    self.wfile.write(str(output).encode('utf-8'))
+                self.wfile.write(output)
             else:
                 self.close_connection = 1
             self.wfile.flush()

--- a/custodia/message/common.py
+++ b/custodia/message/common.py
@@ -61,7 +61,7 @@ class MessageHandler(object):
         """Generates a reply.
 
         :param req: the original request
-        :param output: a json string with the stored output payload
+        :param output: a Python object that can be converted to JSON
         """
 
         raise NotImplementedError

--- a/custodia/message/kem.py
+++ b/custodia/message/kem.py
@@ -197,7 +197,7 @@ class KEMHandler(MessageHandler):
                              self.kkstore.alg,
                              self.client_keys[1], enc)
 
-        return json_encode({'type': 'kem', 'value': value})
+        return {'type': 'kem', 'value': value}
 
 
 class KEMClient(object):
@@ -335,6 +335,7 @@ def _store_keys(keystore, usage, keys):
 
 
 class KEMTests(unittest.TestCase):
+    maxDiff = None
 
     @classmethod
     def setUpClass(cls):
@@ -372,8 +373,9 @@ class KEMTests(unittest.TestCase):
         jtok = make_sig_kem("mykey", None, cli_skey, "RS256")
         kem = KEMHandler({'KEMKeysStore': self.kk})
         kem.parse(jtok, "mykey")
-        out = kem.reply('output')
-        jtok = JWT(jwt=json_decode(out)['value'])
+        msg = kem.reply('output')
+        self.assertEqual(msg, json_decode(json_encode(msg)))
+        jtok = JWT(jwt=msg['value'])
         cli_ekey = JWK(**self.client_keys[1])
         jtok.token.decrypt(cli_ekey)
         nested = jtok.token.payload
@@ -390,7 +392,8 @@ class KEMTests(unittest.TestCase):
         kem = KEMHandler({'KEMKeysStore': self.kk})
         req = cli.make_request("key name")
         kem.parse(req, "key name")
-        msg = json_decode(kem.reply('key value'))
+        msg = kem.reply('key value')
+        self.assertEqual(msg, json_decode(json_encode(msg)))
         rep = cli.parse_reply("key name", msg['value'])
         self.assertEqual(rep, 'key value')
 
@@ -403,7 +406,8 @@ class KEMTests(unittest.TestCase):
         kem = KEMHandler({'KEMKeysStore': self.kk})
         req = cli.make_request("key name", encalg=('RSA1_5', 'A256CBC-HS512'))
         kem.parse(req, "key name")
-        msg = json_decode(kem.reply('key value'))
+        msg = kem.reply('key value')
+        self.assertEqual(msg, json_decode(json_encode(msg)))
         rep = cli.parse_reply("key name", msg['value'])
         self.assertEqual(rep, 'key value')
 

--- a/custodia/message/simple.py
+++ b/custodia/message/simple.py
@@ -1,7 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
 
-import json
-
 from six import string_types
 
 from custodia.message.common import InvalidMessage
@@ -40,5 +38,4 @@ class SimpleKey(MessageHandler):
             # directory listings are pass-through with simple messages
             return output
 
-        return json.dumps({'type': self.msg_type, 'value': output},
-                          separators=(',', ':'))
+        return {'type': self.msg_type, 'value': output}


### PR DESCRIPTION
Handlers no longer have to burden themselves with serialization and
output encoding. They can simply return a Python object and set an
output encoding. The HTTP consumer takes care of transforming the
output to bytes.

Signed-off-by: Christian Heimes <cheimes@redhat.com>