### PR TITLE
Distribute custodia with setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /dist/
 /docs/build
 /tests/tmp
+/*.egg-info
 __pycache__
 *.pyc
 *.pyo
@@ -10,4 +11,6 @@ cscope.out
 .cache
 .coverage
 MANIFEST
-
+custodia.audit.log
+secrets.db
+server_socket

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,17 @@
-include *py *.md *.txt *.ini .coveragerc
-include Makefile
+include setup.py setup.cfg
+include Makefile LICENSE README
+include *.md *.ini .coveragerc
+
+include custodia.conf
 recursive-include examples *.key *.db
+
 recursive-include docs *.py *.rst
+include docs/Makefile
+include man/custodia.7
+
 recursive-include tests *.py
+recursive-include tests/ca *.conf *.key *.pem *.sh
+prune tests/tmp
+prune tests/ca/tmp
+
+exclude server_socket

--- a/README
+++ b/README
@@ -1,21 +1,49 @@
+.. WARNING: AUTO-GENERATED FILE. DO NOT EDIT.
+
+
+|Build Status|
+
 Custodia
 ========
 
 A tool for managing secrets.
 
+Custodia is a project that aims to define an API for modern cloud
+applications that allows to easily store and share passwords, tokens,
+certificates and any other secret in a way that keeps data secure,
+mangeable and auditable.
 
-Custodia is a project that aims to define an API for modern cloud applications
-that allows to easily store and share passwords, tokens, certificates and any
-other secret in a way that keeps data secure, mangeable and auditable.
+The Custodia project offers example implementations of clear text and
+encrypted backends, and aims to soon provide drivers to store data in
+external data stores like the Vault Project, OpenStack's Barbican,
+FreeIPA's Vault and similar.
 
-The Custodia project offers example implementations of clear text and encrypted
-backends, and aims to soon provide drivers to store data in external data
-stores like the Vault Project, OpenStack's Barbican, FreeIPA's Vault and
-similar.
+In future the Custodia project plans to enhance and enrich the API to
+provide access to even more secure means of dealing with private keys,
+like HSM as a Service and other similar security systems.
 
-In future the Custodia project plans to enhance and enrich the API to provide
-access to even more secure means of dealing with private keys, like HSM as a
-Service and other similar security systems.
+See the Custodia wiki for more information about the current
+architecture: https://github.com/latchset/custodia/wiki
 
-See the Custodia wiki for more information about the current architecture:
-https://github.com/latchset/custodia/wiki
+Requirements
+------------
+
+Runtime
+~~~~~~~
+
+-  configparser (Python 2.7)
+-  cryptography
+-  jwcrypto >= 0.2
+-  requests
+-  six
+
+Installation and testing
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  pip
+-  setuptools >= 18.0
+-  tox >= 2.3.1
+-  wheel
+
+.. |Build Status| image:: https://travis-ci.org/latchset/custodia.svg?branch=master
+   :target: https://travis-ci.org/latchset/custodia

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Build Status](https://travis-ci.org/latchset/custodia.svg?branch=master)](https://travis-ci.org/latchset/custodia)
 
-Custodia
-========
+# Custodia
 
 A tool for managing secrets.
 
@@ -21,3 +20,22 @@ Service and other similar security systems.
 
 See the Custodia wiki for more information about the current architecture:
 https://github.com/latchset/custodia/wiki
+
+
+## Requirements
+
+### Runtime
+
+* configparser (Python 2.7)
+* cryptography
+* jwcrypto >= 0.2
+* requests
+* six
+
+### Installation and testing
+
+* pip
+* setuptools >= 18.0
+* tox >= 2.3.1
+* wheel
+

--- a/custodia/custodia
+++ b/custodia/custodia
@@ -1,8 +1,0 @@
-#!/usr/bin/python
-#
-# Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
-
-from custodia.server import main
-
-if __name__ == '__main__':
-    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-jwcrypto
-docker-py
-python-etcd
-six
-requests
-# extended interpolation is provided by stdlib in Python 3.4+
-configparser; python_version < '3.4'

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,33 @@
 #
 # Copyright (C) 2015  Custodia project Contributors, for licensee see COPYING
 
-from distutils.core import setup
+from setuptools import setup
+
+requirements = [
+    'cryptography',
+    'jwcrypto',
+    'six',
+    'requests']
+# configparser; python_version<'3.4'
+# extended interpolation is provided by stdlib in Python 3.4+
+
+# extra requirements
+k8s_requires = ['docker-py']
+etcd_requires = ['python-etcd']
+
+# test requirements
+test_requires = ['coverage', 'pytest'] + k8s_requires + etcd_requires
+test_pylint_requires = ['pylint'] + test_requires
+test_pep8_requires = ['flake8', 'flake8-import-order', 'pep8-naming']
+test_docs_requires = ['docutils', 'markdown']
+
+with open('README') as f:
+    long_description = f.read()
 
 setup(
     name='custodia',
+    descricription='A service to manage, retrieve and store secrets',
+    long_description=long_description,
     version='0.1.90',
     license='GPLv3+',
     maintainer='Custodia project Contributors',
@@ -19,9 +42,29 @@ setup(
         'custodia.server',
         'custodia.store',
     ],
-    data_files=[('share/man/man7', ["man/custodia.7"]),
-                ('share/doc/custodia', ['LICENSE', 'README', 'API.md']),
-                ('share/doc/custodia/examples', ['custodia.conf']),
-                ],
-    scripts=['custodia/custodia']
+    entry_points={
+        'console_scripts': [
+            'custodia = custodia.server:main'
+        ],
+    },
+    classifiers=[
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Intended Audience :: Developers',
+        'Topic :: Security',
+        'Topic :: Software Development :: Libraries :: Python Modules'
+    ],
+    install_requires=requirements,
+    tests_require=test_requires,
+    extras_require={
+        # extended interpolation is provided by stdlib in Python 3.4+
+        ':python_version<"3.4"': ['configparser'],
+        'etcd_store': etcd_requires,
+        'kubernetes': k8s_requires,
+        'test': test_requires,
+        'test_docs': test_docs_requires,
+        'test_pep8': test_pep8_requires,
+        'test_pylint': test_pylint_requires,
+    },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+minversion = 2.3.1
 envlist = lint,py27,py34,py35,pep8py2,pep8py3,doc,sphinx
 skip_missing_interpreters = true
 
@@ -6,61 +7,54 @@ skip_missing_interpreters = true
 setenv =
     PYTHONPATH = {envsitepackagesdir}
 deps =
-    pytest
-    coverage
-    -r{toxinidir}/requirements.txt
-    cryptography
+    .[test]
+# all tests use packages from global site-packages directory
 sitepackages = True
 commands =
-    {envpython} -m coverage run -m pytest --capture=no --strict {posargs}
+    {envpython} -m coverage run --append \
+        -m pytest --capture=no --strict {posargs}
     {envpython} -m coverage report -m
 
 [testenv:lint]
 basepython = python2.7
 deps =
-    pylint
-    -r{toxinidir}/requirements.txt
-    cryptography
-sitepackages = True
+    .[test_pylint]
 commands =
     {envpython} -m pylint -d c,r,i,W0613 -r n --notes= --disable=star-args ./custodia
+    # tox doesn't expand *.py and pylint treats ./tests/ as a package
+    {envpython} -m pylint -d c,r,i,W0613 -r n --notes= --disable=star-args \
+	tests/test_authenticators.py  \
+        tests/test_custodia.py \
+        tests/test_message_kem.py \
+        tests/test_secrets.py \
+        tests/test_store.py \
+        tests/test_store_sqlite.py
 
 [testenv:pep8py2]
 basepython = python2.7
 deps =
-    flake8
-    flake8-import-order
-    pep8-naming
-sitepackages = True
+    .[test_pep8]
 commands =
     {envpython} -m flake8 {posargs}
 
 [testenv:pep8py3]
 basepython = python3
 deps =
-    flake8
-    flake8-import-order
-    pep8-naming
-sitepackages = True
+    .[test_pep8]
 commands =
     {envpython} -m flake8 {posargs}
 
 [testenv:doc]
 basepython = python3
 deps =
-    doc8
-    docutils
-    markdown
-sitepackages = True
+    .[test_docs]
 commands =
-    doc8 --allow-long-titles README
     python setup.py check --restructuredtext --metadata --strict
     markdown_py README.md -f {toxworkdir}/README.md.html
     markdown_py API.md -f {toxworkdir}/API.md.html
 
 [testenv:sphinx]
 basepython = python3
-sitepackages = True
 changedir = docs/source
 deps =
     sphinx
@@ -69,6 +63,7 @@ commands =
 
 [pytest]
 norecursedirs = build .tox
+python_files = tests/*.py
 
 [flake8]
 exclude = .tox,*.egg,dist,build,docs/source


### PR DESCRIPTION
Custodia now uses setuptools instead of distutils.

- The script custodia/custodia is replaced by a console script entry
  point. You can use 'make run' to start a local test instance of
  Custodia.
- Dependencies are now tracked in egg-info metadata. This includes
  optional dependencies and test requirements.
- setuptools does not support data_files, use make instead:
  $ install PREFIX=/usr PYTHON=python3.5

Signed-off-by: Christian Heimes <cheimes@redhat.com>