### PR TITLE
Add systemd socket activation

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -16,6 +16,13 @@ server_url [str]
    * https://hostname:port
    * http+unix://%2Fpath%2Fto%2Fserver_sock
 
+   Custodia supports systemd socket activation. The server automatically
+   detects socket activation and uses the first file descriptor (requires
+   python-systemd). Socket family and port/path must match settings in
+   configuration file::
+
+       $ /usr/lib/systemd/systemd-activate -l $(pwd)/custodia.sock python -m custodia.server custodia.conf
+
 server_socket [str]
    Path to :const:`AF_UNIX` socket file.
 


### PR DESCRIPTION
Three new server URL schemes add support for systemd socket activation
on Unix sockets or TCP sockets (plain HTTP or HTTPS). systemd+https is
not supported on Python 2.7 because of limitation in Python's ssl
module.

systemd+unix://
systemd+http://
systemd+https://

Closes: #40
Signed-off-by: Christian Heimes <cheimes@redhat.com>