### PR TITLE
Support user and group name for SimpleCredsAuth plugin

### DIFF
--- a/custodia/httpd/authenticators.py
+++ b/custodia/httpd/authenticators.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
 
+import grp
 import os
+import pwd
 
 from cryptography.hazmat.primitives import constant_time
 
@@ -18,12 +20,23 @@ class SimpleCredsAuth(HTTPAuthenticator):
 
     def __init__(self, config=None):
         super(SimpleCredsAuth, self).__init__(config)
-        self._uid = 0
-        self._gid = 0
-        if 'uid' in self.config:
-            self._uid = int(self.config['uid'])
-        if 'gid' in self.config:
-            self._gid = int(self.config['gid'])
+        uid = self.config.get('uid')
+        if uid is None:
+            self._uid = 0
+        else:
+            try:
+                self._uid = int(uid)
+            except ValueError:
+                self._uid = pwd.getpwnam(uid).pw_uid
+
+        gid = self.config.get('gid')
+        if gid is None:
+            self._gid = 0
+        else:
+            try:
+                self._gid = int(gid)
+            except ValueError:
+                self._gid = grp.getgrnam(gid).gr_gid
 
     def handle(self, request):
         creds = request.get('creds')

--- a/tests/test_authenticators.py
+++ b/tests/test_authenticators.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2016  Custodia Project Contributors - see LICENSE file
+
+from __future__ import absolute_import
+
+import grp
+import os
+import pwd
+import unittest
+
+from custodia.httpd import authenticators
+
+
+class TestAuthenticators(unittest.TestCase):
+    def test_cred(self):
+        # pylint: disable=protected-access
+        cred = authenticators.SimpleCredsAuth({})
+        self.assertEqual(cred._uid, 0)
+        self.assertEqual(cred._gid, 0)
+
+        cred = authenticators.SimpleCredsAuth({'uid': '0', 'gid': '0'})
+        self.assertEqual(cred._uid, 0)
+        self.assertEqual(cred._gid, 0)
+
+        cred = authenticators.SimpleCredsAuth({'uid': 'root', 'gid': 'root'})
+        self.assertEqual(cred._uid, 0)
+        self.assertEqual(cred._gid, 0)
+
+        user = pwd.getpwuid(os.getuid())
+        group = grp.getgrgid(user.pw_gid)
+
+        cred = authenticators.SimpleCredsAuth(
+            {'uid': user.pw_name, 'gid': group.gr_name})
+        self.assertNotEqual(cred._uid, 0)
+        self.assertEqual(cred._uid, user.pw_uid)
+        self.assertNotEqual(cred._gid, 0)
+        self.assertEqual(cred._gid, group.gr_gid)


### PR DESCRIPTION
The SimpleCredsAuth authenticator plugin used to support numeric uid and
gid only. Now it is able to lookup uid and gid by user name and group
name, too.

Closed: #33
Signed-off-by: Christian Heimes <cheimes@redhat.com>