### PR TITLE
EncryptedOverlay can auto-generate encryption key

### DIFF
--- a/custodia/store/encgen.py
+++ b/custodia/store/encgen.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
 
+import os
+
 from jwcrypto.common import json_decode, json_encode
 from jwcrypto.jwe import JWE
 from jwcrypto.jwk import JWK
@@ -8,6 +10,22 @@ from custodia.store.interface import CSStore, CSStoreError
 
 
 class EncryptedOverlay(CSStore):
+    """Encrypted overlay for storage backends
+
+    Arguments:
+        backing_store (required):
+            name of backing storage
+        master_key (required)
+            path to master key (JWK JSON)
+        autogen_master_key (default: false)
+            auto-generate key file if missing?
+        master_enctype (default: A256CBC_HS512)
+            JWE algorithm name
+    """
+    key_sizes = {
+        'A128CBC-HS256': 256,
+        'A256CBC-HS512': 512,
+    }
 
     def __init__(self, config):
         super(EncryptedOverlay, self).__init__(config)
@@ -17,15 +35,25 @@ class EncryptedOverlay(CSStore):
         self.store_name = config['backing_store']
         self.store = None
 
-        if 'master_key' not in config:
+        self.enc = config.get('master_enctype', 'A256CBC-HS512')
+        master_key_file = config.get('master_key')
+
+        if master_key_file is None:
             raise ValueError('Missing "master_key" for Encrypted Store')
 
-        with open(config['master_key']) as f:
+        if (not os.path.isfile(master_key_file) and
+                config.get('autogen_master_key') == 'true'):
+            # XXX https://github.com/latchset/jwcrypto/issues/50
+            size = self.key_sizes.get(self.enc, 512)
+            key = JWK(generate='oct', size=size)
+            with open(master_key_file, 'w') as f:
+                os.fchmod(f.fileno(), 0o600)
+                f.write(key.export())
+
+        with open(master_key_file) as f:
             data = f.read()
             key = json_decode(data)
             self.mkey = JWK(**key)
-
-        self.enc = config.get('master_enctype', 'A256CBC_HS512')
 
     def get(self, key):
         value = self.store.get(key)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2016  Custodia Project Contributors - see LICENSE file
+from __future__ import print_function
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from custodia.store.encgen import EncryptedOverlay
+from custodia.store.interface import CSStoreError
+from custodia.store.sqlite import SqliteStore
+
+
+class EncryptedOverlayTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.backing_store = SqliteStore(
+            {'dburi': os.path.join(self.tmpdir, 'teststore.sqlite')}
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_autogen(self):
+        master_key = os.path.join(self.tmpdir, 'master.key')
+        with self.assertRaises(IOError):
+            EncryptedOverlay({
+                'backing_store': 'teststore',
+                'master_key': master_key})
+
+        self.assertFalse(os.path.isfile(master_key))
+        enc = EncryptedOverlay({
+            'backing_store': 'teststore',
+            'master_key': master_key,
+            'autogen_master_key': 'true'
+        })
+        self.assertTrue(os.path.isfile(master_key))
+        stats = os.stat(master_key)
+
+        # second attempt does not override master key
+        enc = EncryptedOverlay({
+            'backing_store': 'teststore',
+            'master_key': master_key,
+            'autogen_master_key': 'true'
+        })
+        self.assertEqual(stats, os.stat(master_key))
+
+        enc.store = self.backing_store
+        enc.set('key', 'value')
+        self.assertEqual(enc.get('key'), 'value')
+        self.assertNotEqual(enc.store.get('key'), 'value')
+
+        # new master key
+        os.unlink(master_key)
+        enc2 = EncryptedOverlay({
+            'backing_store': 'teststore',
+            'master_key': master_key,
+            'autogen_master_key': 'true'
+        })
+        enc2.store = self.backing_store
+        with self.assertRaises(CSStoreError):
+            # different key causes MAC error during decryption
+            self.assertEqual(enc2.get('key'), 'value')


### PR DESCRIPTION
The new option 'autogen_master_key=true' auto-generates a symmetric JWK
when master_key file does not exist on start.

Closes: #39
Signed-off-by: Christian Heimes <cheimes@redhat.com>