### PR TITLE
Add global umask and sqlite filemode options

### DIFF
--- a/custodia.conf
+++ b/custodia.conf
@@ -17,6 +17,7 @@ tls_certfile = tests/ca/custodia-server.pem
 tls_keyfile = tests/ca/custodia-server.key
 tls_cafile = tests/ca/custodia-ca.pem
 tls_verify_client = true
+umask = 027
 
 #[auth:simple]
 #handler = custodia.httpd.authenticators.SimpleCredsAuth
@@ -40,6 +41,7 @@ store = simple
 handler = custodia.store.sqlite.SqliteStore
 dburi = secrets.db
 table = secrets
+filemode = 640
 
 [/]
 handler = custodia.root.Root

--- a/custodia/server/__init__.py
+++ b/custodia/server/__init__.py
@@ -74,8 +74,10 @@ def parse_config(cfgfile):
             'global', 'tls_verify_client', fallback=False)
         config['debug'] = parser.getboolean(
             'global', 'debug', fallback=False)
+
         config['auditlog'] = os.path.abspath(
             config.get('auditlog', 'custodia.audit.log'))
+        config['umask'] = int(config.get('umask', '027'), 8)
 
         url = config.get('server_url')
         if url and 'server_socket' in config:
@@ -86,6 +88,9 @@ def parse_config(cfgfile):
                 config.get('server_socket', 'server_socket'))
             config['server_url'] = 'http+unix://{}/'.format(
                 url_escape(server_socket, ''))
+
+    # set umask before any plugin gets a chance to create a file
+    os.umask(config['umask'])
 
     for s in parser.sections():
         if s in {'ENV', 'global'}:

--- a/custodia/store/sqlite.py
+++ b/custodia/store/sqlite.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
-
 from __future__ import print_function
 
+import os
 import sqlite3
 
 from custodia.store.interface import CSStore, CSStoreError, CSStoreExists
@@ -19,9 +19,12 @@ class SqliteStore(CSStore):
         else:
             self.table = "CustodiaSecrets"
 
+        filemode = int(config.get('filemode', '600'), 8)
+
         # Initialize the DB by trying to create the default table
         try:
             conn = sqlite3.connect(self.dburi)
+            os.chmod(self.dburi, filemode)
             with conn:
                 c = conn.cursor()
                 self._create(c)

--- a/tests/test_custodia.py
+++ b/tests/test_custodia.py
@@ -39,6 +39,7 @@ tls_certfile = tests/ca/custodia-server.pem
 tls_keyfile = tests/ca/custodia-server.key
 tls_cafile = tests/ca/custodia-ca.pem
 tls_verify_client = ${VERIFY_CLIENT}
+umask = 027
 
 [auth:header]
 handler = custodia.httpd.authenticators.SimpleHeaderAuth
@@ -60,6 +61,7 @@ store = simple
 handler = custodia.store.sqlite.SqliteStore
 dburi = ${TEST_DIR}/test_secrets.db
 table = secrets
+filemode = 640
 
 [/secrets]
 handler = custodia.secrets.Secrets


### PR DESCRIPTION
The server used to create files like audit log and sqlite DB
world-readable. The process umask now defaults to 027 and the db is
created with 600. The default values can be overwritten in config.
    
Closes: #48
Signed-off-by: Christian Heimes <cheimes@redhat.com>
