### PR TITLE
Make server_url or server_socket required, mutual exclusive options

### DIFF
--- a/custodia.conf
+++ b/custodia.conf
@@ -13,6 +13,7 @@
 server_version = "Secret/0.0.7"
 debug = True
 #server_url = https://0.0.0.0:10443
+server_socket = ./server_socket
 tls_certfile = tests/ca/custodia-server.pem
 tls_keyfile = tests/ca/custodia-server.key
 tls_cafile = tests/ca/custodia-ca.pem

--- a/custodia/server/__init__.py
+++ b/custodia/server/__init__.py
@@ -80,12 +80,12 @@ def parse_config(cfgfile):
         config['umask'] = int(config.get('umask', '027'), 8)
 
         url = config.get('server_url')
-        if url and 'server_socket' in config:
-            raise ValueError(
-                "'server_url' and ''server_socket'' are mutual exclusive")
-        if url is None:
-            server_socket = os.path.abspath(
-                config.get('server_socket', 'server_socket'))
+        sock = config.get('server_socket')
+        if bool(url) == bool(sock):
+            raise ValueError("Exactly one of 'server_url' or "
+                             "'server_socket' is required.")
+        if sock:
+            server_socket = os.path.abspath(sock)
             config['server_url'] = 'http+unix://{}/'.format(
                 url_escape(server_socket, ''))
 


### PR DESCRIPTION
Custodia no longer defaults to 'server_socket' in the current working
directory. Custodia's config file must contain either a server_url or a
server_socket option.

Closes: #38
Signed-off-by: Christian Heimes <cheimes@redhat.com>
