### PR TITLE
Add setup.cfg with release aliases

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[bdist_wheel]
+universal = 1
+
+[aliases]
+# requires setuptools and wheel package
+# dnf install python3-setuptools python3-wheel
+packages = clean --all egg_info bdist_wheel sdist --format=zip sdist --format=gztar
+release = packages register upload


### PR DESCRIPTION
setup.cfg adds a flag for universal builds and two aliases to build
and upload packages. A PyPY release becomes as simple as

    python setup.py release

Signed-off-by: Christian Heimes <cheimes@redhat.com>