### PR TITLE
Use PEP 440 version schema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     name='custodia',
     descricription='A service to manage, retrieve and store secrets',
     long_description=long_description,
-    version='0.1.90',
+    version='0.2.dev1',
     license='GPLv3+',
     maintainer='Custodia project Contributors',
     maintainer_email='simo@redhat.com',


### PR DESCRIPTION
Version 0.2.dev1 is the development version of 0.2. PEP 440 version
number allows us to distribute pre-relases and development releases on
PyPI.

https://www.python.org/dev/peps/pep-0440/

Signed-off-by: Christian Heimes <cheimes@redhat.com>