### PR TITLE
Misc minor fixes

### DIFF
--- a/custodia/cli/__init__.py
+++ b/custodia/cli/__init__.py
@@ -35,7 +35,9 @@ def server_check(arg):
 
 
 main_parser.add_argument(
-    '--server', type=server_check, default='/var/run/custodia.sock',
+    '--server',
+    type=server_check,
+    default='/var/run/custodia/custodia.sock',
     help='Custodia server'
 )
 main_parser.add_argument(
@@ -69,7 +71,7 @@ def handle_name(args):
     return func(args.name)
 
 
-def handle_name_value(client, args):
+def handle_name_value(args):
     client = args.client_conn
     func = getattr(client, args.command)
     return func(args.name, args.value)

--- a/custodia/httpd/server.py
+++ b/custodia/httpd/server.py
@@ -104,7 +104,11 @@ class ForkingUnixHTTPServer(ForkingHTTPServer):
 
     def server_bind(self):
         self.unlink()
+        # Remove on exit
         atexit.register(self.unlink)
+        basedir = os.path.dirname(self.server_address)
+        if not os.path.isdir(basedir):
+            os.makedirs(basedir, mode=0o755)
         ForkingHTTPServer.server_bind(self)
         os.chmod(self.server_address, 0o666)
 


### PR DESCRIPTION
- custodia.cli set was broken.
- Move custodia.sock into /var/run/custodia/ directory.
- Auto-create directory.

Signed-off-by: Christian Heimes <cheimes@redhat.com>

I need to write some tests for the command line interface.