### PR TITLE
Keep reserved characters in pathquoted

### DIFF
--- a/custodia/httpd/server.py
+++ b/custodia/httpd/server.py
@@ -186,6 +186,11 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
 
     protocol_version = "HTTP/1.0"
 
+    # RFC 2396 reserved chars
+    path_translation = {
+        ord(s): u'%{:02X}'.format(ord(s)) for s in ';/?:@&+$,'
+    }
+
     def __init__(self, *args, **kwargs):
         self.requestline = ''
         self.request_version = ''
@@ -271,7 +276,8 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
         url = urlparse(self.path)
 
         # Yes, override path with the path part only
-        self.path = unquote(url.path)
+
+        self.path = self.parse_path(url.path)
 
         # Create dict out of query
         self.query = parse_qs(url.query)
@@ -280,6 +286,16 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
         self.url = url
 
         return True
+
+    def parse_path(self, path):
+        segments = []
+        for seg in path.split('/'):
+            seg = unquote(seg)
+            if not isinstance(seg, six.text_type):
+                seg = seg.decode('utf-8')
+            # quote /:? again
+            segments.append(seg.translate(self.path_translation))
+        return u'/'.join(segments)
 
     def parse_body(self):
         length = int(self.headers.get('content-length', 0))

--- a/tests/test_custodia.py
+++ b/tests/test_custodia.py
@@ -9,8 +9,14 @@ import subprocess
 import sys
 import time
 import unittest
-
 from string import Template
+
+try:
+    # pylint: disable=import-error
+    from urllib import quote_plus
+except ImportError:
+    # pylint: disable=import-error,no-name-in-module
+    from urllib.parse import quote_plus
 
 from jwcrypto import jwk
 
@@ -229,19 +235,28 @@ class CustodiaTests(unittest.TestCase):
 
     def test_1_set_simple_key(self):
         self.client.set_secret('test/key', 'VmVycnlTZWNyZXQK')
+        urlkey = 'test/{}'.format(quote_plus('http://localhost:5000'))
+        self.client.set_secret(urlkey, 'path with /')
 
     def test_2_get_simple_key(self):
         key = self.client.get_secret('test/key')
         self.assertEqual(key, 'VmVycnlTZWNyZXQK')
+        key = self.client.get_secret('test/http%3A%2F%2Flocalhost%3A5000')
+        self.assertEqual(key, 'path with /')
 
     def test_3_list_container(self):
         cl = self.client.list_container('test')
-        self.assertEqual(cl, ["key"])
+        self.assertEqual(cl, ["http%3A%2F%2Flocalhost%3A5000", "key"])
 
     def test_4_del_simple_key(self):
         self.client.del_secret('test/key')
+        self.client.del_secret('test/http%3A%2F%2Flocalhost%3A5000')
         try:
             self.client.get_secret('test/key')
+        except HTTPError:
+            self.assertEqual(self.client.last_response.status_code, 404)
+        try:
+            self.client.get_secret('test/http%3A%2F%2Flocalhost%3A5000')
         except HTTPError:
             self.assertEqual(self.client.last_response.status_code, 404)
 


### PR DESCRIPTION
RFC 2396 special characters in url path like / are no longer unquoted
but kept quoted. This allows URLs to be used as secret keys.

Closes: #60
Signed-off-by: Christian Heimes <cheimes@redhat.com>