### PR TITLE
Use RSA-OAEP instead of PKCS#1 v1.5 padding

### DIFF
--- a/custodia/client.py
+++ b/custodia/client.py
@@ -221,7 +221,7 @@ class CustodiaKEMClient(CustodiaHTTPClient):
         if self._enc_alg is not None:
             return self._enc_alg
         elif key.key_type == 'RSA':
-            return ('RSA1_5', 'A256CBC-HS512')
+            return ('RSA-OAEP', 'A256CBC-HS512')
         elif key.key_type == 'EC':
             return ('ECDH-ES+A256KW', 'A256CBC-HS512')
         else:

--- a/custodia/message/kem.py
+++ b/custodia/message/kem.py
@@ -186,7 +186,7 @@ class KEMHandler(MessageHandler):
 
         ktype = self.client_keys[KEY_USAGE_ENC].key_type
         if ktype == 'RSA':
-            enc = ('RSA1_5', 'A256CBC-HS512')
+            enc = ('RSA-OAEP', 'A256CBC-HS512')
         else:
             raise ValueError("'%s' type not supported yet" % ktype)
 

--- a/tests/test_message_kem.py
+++ b/tests/test_message_kem.py
@@ -169,7 +169,8 @@ class KEMTests(unittest.TestCase):
                        JWK(**self.client_keys[kem.KEY_USAGE_ENC])]
         cli = kem.KEMClient(server_keys, client_keys)
         kh = kem.KEMHandler({'KEMKeysStore': self.kk})
-        req = cli.make_request("key name", encalg=('RSA1_5', 'A256CBC-HS512'))
+        req = cli.make_request("key name",
+                               encalg=('RSA-OAEP', 'A256CBC-HS512'))
         kh.parse(req, "key name")
         msg = kh.reply('key value')
         self.assertEqual(msg, json_decode(json_encode(msg)))


### PR DESCRIPTION
PKCS#1 v1.5 padding can be turned into a padding oracle. OAEP (PKCS#1
v2.0) is more secure and preferred. RSA-OAEP uses SHA1. RSA-OAEP-256 is not
supported by some cryptography backends.

Signed-off-by: Christian Heimes <cheimes@redhat.com>