### PR TITLE
Add --skip-servertests option

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,29 @@
 # Copyright (C) 2016  Custodia Project Contributors - see LICENSE file
 import warnings
 
+import pytest
+
 from custodia.log import ProvisionalWarning
 
 # silence our own warnings about provisional APIs
 warnings.simplefilter('ignore', category=ProvisionalWarning)
 # deprecated APIs raise an exception
 warnings.simplefilter('error', category=DeprecationWarning)
+
+
+SKIP_SERVERTEST = "--skip-servertests"
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        SKIP_SERVERTEST,
+        action="store_true",
+        help="Skip integration tests"
+    )
+
+
+def pytest_runtest_setup(item):
+    skip_servertest = item.config.getoption(SKIP_SERVERTEST)
+    if skip_servertest and item.get_marker("servertest") is not None:
+        # args has --skip-servertests and test is marked as servertest
+        pytest.skip("Skip integration test")

--- a/tests/test_custodia.py
+++ b/tests/test_custodia.py
@@ -14,10 +14,16 @@ from string import Template
 
 from jwcrypto import jwk
 
+import pytest
+
 from requests.exceptions import HTTPError, SSLError
 
 from custodia.client import CustodiaKEMClient, CustodiaSimpleClient
 from custodia.store.sqlite import SqliteStore
+
+
+# mark all tests in this module as 'servertest' test cases
+pytestmark = pytest.mark.servertest
 
 
 def find_port(host='localhost'):

--- a/tox.ini
+++ b/tox.ini
@@ -36,14 +36,14 @@ basepython = python2.7
 deps =
     .[test_pep8]
 commands =
-    {envpython} -m flake8 {posargs}
+    {envpython} -m flake8
 
 [testenv:pep8py3]
 basepython = python3
 deps =
     .[test_pep8]
 commands =
-    {envpython} -m flake8 {posargs}
+    {envpython} -m flake8
 
 [testenv:doc]
 basepython = python3
@@ -65,6 +65,9 @@ commands =
 [pytest]
 norecursedirs = build .tox
 python_files = tests/*.py
+markers =
+    # use tox -- --skip-servertests to skip server tests
+    servertest: Integration tests start a local Custodia server
 
 [flake8]
 exclude = .tox,*.egg,dist,build,docs/source


### PR DESCRIPTION
A new options makes it possible to run only unit test and skip
integration tests. tox -- --skip-servertests skip all integration tests
that spawn a Custodia server instance.

Closes: #72
Signed-off-by: Christian Heimes <cheimes@redhat.com>