### PR TITLE
Support relative path to unix socket

### DIFF
--- a/custodia/cli/__init__.py
+++ b/custodia/cli/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2016  Custodia Project Contributors - see LICENSE file
 import argparse
+import os
 import sys
 import traceback
 
@@ -30,6 +31,11 @@ def server_check(arg):
     """
     if arg.startswith(('http://', 'https://', 'http+unix://')):
         return arg
+    if arg.startswith('./'):
+        arg = os.path.abspath(arg)
+    elif not arg.startswith('/'):
+        raise argparse.ArgumentTypeError(
+            'Unix socket path must start with / or ./')
     # assume it is a unix socket
     return 'http+unix://{}'.format(url_escape(arg, ''))
 
@@ -38,7 +44,8 @@ main_parser.add_argument(
     '--server',
     type=server_check,
     default='/var/run/custodia/custodia.sock',
-    help='Custodia server'
+    help=('Custodia server location, supports http://, https://, '
+          'or path to a unix socket.')
 )
 main_parser.add_argument(
     '--uds-urlpath', type=str, default='/secrets/',


### PR DESCRIPTION
custodia.cli now supports relative paths to a unix socket. Relative path
must start with ./ to avoid confusion with host names.

Closes: #76
Signed-off-by: Christian Heimes <cheimes@redhat.com>