### PR TITLE
Disable intersphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,7 @@ sys.path.insert(0, os.path.join(HERE, '..', '..'))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
-    'sphinx.ext.intersphinx',
+    # 'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
 ]
 
@@ -269,4 +269,5 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+# Disabled, see https://github.com/latchset/custodia/issues/13
+# intersphinx_mapping = {'http://docs.python.org/': None}


### PR DESCRIPTION
Interspinx downloads an inventory file from docs.python.org. Custodia
doesn't need the feature. It just slows down make html and causes
trouble for packagers.

Closes: #13
Signed-off-by: Christian Heimes <cheimes@redhat.com>