### PR TITLE
Make 'custodia' a namespace package

### DIFF
--- a/custodia/__init__.py
+++ b/custodia/__init__.py
@@ -1,0 +1,3 @@
+# custodia namespace
+# You must NOT include any other code and data in __init__.py
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
     maintainer='Custodia project Contributors',
     maintainer_email='simo@redhat.com',
     url='https://github.com/latchset/custodia',
+    namespace_packages=['custodia'],
     packages=[
         'custodia',
         'custodia.cli',


### PR DESCRIPTION
I'm planning to move custodia.kubernetes out of the default installation to an external project. I don't like to have experimental and unstable code in custodia releases. namespace packages will allow me to reuse custodia.kubernetes in an external package.

https://setuptools.readthedocs.io/en/latest/setuptools.html#namespace-packages

Signed-off-by: Christian Heimes <cheimes@redhat.com>