### PR TITLE
Relax abstract methods of CSStore

### DIFF
--- a/custodia/plugin.py
+++ b/custodia/plugin.py
@@ -328,17 +328,19 @@ class CSStore(CustodiaPlugin):
     def set(self, key, value, replace=False):
         pass
 
-    @abc.abstractmethod
+    # relax ABC for now, see https://github.com/latchset/custodia/issues/84
+
+    # @abc.abstractmethod
     def span(self, key):
-        pass
+        raise NotImplementedError
 
-    @abc.abstractmethod
+    # @abc.abstractmethod
     def list(self, keyfilter=None):
-        pass
+        raise NotImplementedError
 
-    @abc.abstractmethod
+    # @abc.abstractmethod
     def cut(self, key):
-        pass
+        raise NotImplementedError
 
 
 class HTTPAuthorizer(CustodiaPlugin):


### PR DESCRIPTION
span, list and cut are no longer abstract methods for backward
compatibility reasons. Instead they raise NotImplementedError.

Closes: #84
Signed-off-by: Christian Heimes <cheimes@redhat.com>