### PR TITLE
Misc packaging and testing fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,9 @@ recursive-include docs *.py *.rst
 include docs/Makefile
 include man/custodia.7
 
+include contrib/config/custodia.*
+include contrib/config/README.txt
+
 recursive-include tests *.py
 recursive-include tests/ca *.conf *.key *.pem *.sh
 prune tests/tmp

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CONF := custodia.conf
 PREFIX := /usr
 PYTHON := python3
+TOX := $(PYTHON) -m tox
 DOCS_DIR = docs
 
 .NOTPARALLEL:
@@ -13,14 +14,14 @@ clean_socket:
 	rm -f server_socket
 
 lint: clean_socket
-	tox -e lint
+	$(TOX) -e lint
 
 pep8: clean_socket
-	tox -e pep8py2
-	tox -e pep8py3
+	$(TOX) -e pep8py2
+	$(TOX) -e pep8py3
 
 clean: clean_socket
-	rm -fr build dist *.egg-info .tox MANIFEST .coverage .cache
+	rm -fr build dist *.egg-info .$(TOX) MANIFEST .coverage .cache
 	rm -f custodia.audit.log secrets.db
 	rm -rf docs/build
 	find ./ -name '*.py[co]' -exec rm -f {} \;
@@ -32,9 +33,10 @@ cscope:
 
 test: clean_socket
 	rm -f .coverage
-	tox --skip-missing-interpreters -e py27
-	tox --skip-missing-interpreters -e py34
-	tox --skip-missing-interpreters -e py35
+	$(TOX) --skip-missing-interpreters -e py27
+	$(TOX) --skip-missing-interpreters -e py34
+	$(TOX) --skip-missing-interpreters -e py35
+	$(TOX) --skip-missing-interpreters -e doc
 
 README: README.md
 	echo -e '.. WARNING: AUTO-GENERATED FILE. DO NOT EDIT.\n' > $@

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ custodia_stores = [
 
 setup(
     name='custodia',
-    descricription='A service to manage, retrieve and store secrets',
+    description='A service to manage, retrieve and store secrets',
     long_description=long_description,
     version='0.3.dev1',
     license='GPLv3+',

--- a/tox.ini
+++ b/tox.ini
@@ -51,8 +51,8 @@ deps =
     .[test_docs]
 commands =
     python setup.py check --restructuredtext --metadata --strict
-    markdown_py README.md -f {toxworkdir}/README.md.html
-    markdown_py API.md -f {toxworkdir}/API.md.html
+    {envpython} -m markdown README.md -f {toxworkdir}/README.md.html
+    {envpython} -m markdown API.md -f {toxworkdir}/API.md.html
 
 [testenv:sphinx]
 basepython = python3
@@ -60,7 +60,7 @@ changedir = docs/source
 deps =
     sphinx
 commands =
-    sphinx-build -v -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+    {envpython} -m sphinx -v -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [pytest]
 norecursedirs = build .tox


### PR DESCRIPTION
- fix typo 'descricription' in setup.py
- use 'python -m module' instead of script for tox and markdown to work
  around different names for Python 2 and 3 entry points.
- run 'tox -e doc' in 'make test'
- include example configs from contrib/

Closes: #90
Signed-off-by: Christian Heimes <cheimes@redhat.com>