### PR TITLE
Fix three linter / pep8 errors

### DIFF
--- a/custodia/cli/__init__.py
+++ b/custodia/cli/__init__.py
@@ -167,6 +167,7 @@ def handle_plugins(args):
         result.append('')
     return result[:-1]
 
+
 parser_plugins = subparsers.add_parser(
     'plugins', help='List plugins')
 parser_plugins.set_defaults(

--- a/custodia/client.py
+++ b/custodia/client.py
@@ -33,7 +33,7 @@ class HTTPUnixConnection(HTTPConnection):
         s = socket.socket(family=socket.AF_UNIX)
         s.settimeout(self.timeout)
         s.connect(self.unix_socket)
-        self.sock = s
+        self.sock = s  # pylint: disable=attribute-defined-outside-init
 
 
 class HTTPUnixConnectionPool(HTTPConnectionPool):

--- a/custodia/log.py
+++ b/custodia/log.py
@@ -105,6 +105,7 @@ class AuditLog(object):
         args = {'cli': client, 'name': name}
         self.logger.info(msg, args, extra={'origin': origin})
 
+
 auditlog = AuditLog(logging.getLogger('custodia.audit'))
 
 


### PR DESCRIPTION
The latest versions of pylint and flake8 complain about additional
violations in Custodia.

Signed-off-by: Christian Heimes <cheimes@redhat.com>