### PR TITLE
Move sitepackages=true from tox.ini to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CONF := custodia.conf
 PREFIX := /usr
 PYTHON := python3
-TOX := $(PYTHON) -m tox
+TOX := $(PYTHON) -m tox --sitepackages
 DOCS_DIR = docs
 
 .NOTPARALLEL:

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,8 @@ setenv =
     PYTHONPATH = {envsitepackagesdir}
 deps =
     .[test]
-# all tests use packages from global site-packages directory
-sitepackages = True
+# Makefile and RPM spec set sitepackages=True
+sitepackages = False
 commands =
     {envpython} -m coverage run --append \
         -m pytest --capture=no --strict {posargs}


### PR DESCRIPTION
Custodia uses tox's sitepackages option to test compatibility with
distribution packages. This patch allows us to test both distribution
compatibility and upstream compatibility easily. 'make test' defaults to
distribution packages, 'tox' to upstream packages.

Signed-off-by: Christian Heimes <cheimes@redhat.com>