### PR TITLE
Add FQDN to config defaults

### DIFF
--- a/custodia/server/__init__.py
+++ b/custodia/server/__init__.py
@@ -9,6 +9,7 @@ import argparse
 import importlib
 import logging
 import os
+import socket
 
 # use https://pypi.python.org/pypi/configparser/ on Python 2
 from configparser import ConfigParser, ExtendedInterpolation
@@ -100,7 +101,16 @@ def _create_plugin(parser, section, menu):
 
 
 def parse_config(args):
-    parser = ConfigParser(interpolation=ExtendedInterpolation())
+    defaults = {
+        # Do not use getfqdn(). Internaly it calls gethostbyaddr which might
+        # perform a DNS query.
+        'hostname': socket.gethostname(),
+    }
+
+    parser = ConfigParser(
+        interpolation=ExtendedInterpolation(),
+        defaults=defaults
+    )
     parser.optionxform = str
 
     with args.configfile as f:


### PR DESCRIPTION
With the FQDN hostname in defaults, a config file can refer to the
current hostname without spelling it out. It makes it a bit easier to
reuse the same config file in containers.

Signed-off-by: Christian Heimes <cheimes@redhat.com>