### PR TITLE
Correct socket path in documentation examples

### DIFF
--- a/docs/source/examples/misc.rst
+++ b/docs/source/examples/misc.rst
@@ -17,22 +17,22 @@ curl
 
 Test Custodia::
 
-    $ curl --unix-socket /var/run/custodia.sock -X GET http://localhost/
+    $ curl --unix-socket /var/run/custodia/custodia.sock -X GET http://localhost/
     {"message": "Quis custodiet ipsos custodes?"}
 
 Initialize a container for secrets::
 
-    $ curl --unix-socket /var/run/custodia.sock -X POST http://localhost/secrets/container/
+    $ curl --unix-socket /var/run/custodia/custodia.sock -X POST http://localhost/secrets/container/
 
 Create or update a secret::
 
-    $ curl --unix-socket /var/run/custodia.sock -H "Content-Type: application/json" -X PUT http://localhost/secrets/container/key -d '{"type": "simple", "value": "secret value"}'
+    $ curl --unix-socket /var/run/custodia/custodia.sock -H "Content-Type: application/json" -X PUT http://localhost/secrets/container/key -d '{"type": "simple", "value": "secret value"}'
 
 Get a secret::
 
-    $ curl --unix-socket /var/run/custodia.sock -X GET http://localhost/secrets/container/key
+    $ curl --unix-socket /var/run/custodia/custodia.sock -X GET http://localhost/secrets/container/key
     {"type":"simple","value":"secret value"}
 
 Delete a secret::
 
-    $ curl --unix-socket /var/run/custodia.sock -X DELETE http://localhost/secrets/container/key
+    $ curl --unix-socket /var/run/custodia/custodia.sock -X DELETE http://localhost/secrets/container/key


### PR DESCRIPTION
The path to the custodia socket file in the documentation examples
omits the top level "custodia" element.  This causes the examples
to fail.  This patch corrects the path in the examples.