### PR TITLE
Bump Fedora version to 25 in Dockerfile

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:24
+FROM fedora:25
 MAINTAINER Christian Heimes <cheimes@redhat.com>
 
 RUN dnf -y update && dnf clean all


### PR DESCRIPTION
The custodia Dockerfile is still based on Fedora 24.  Fedora 25 has
been released for a while now, so we should switch the container to
use this more recent version.