### PR TITLE
Add /etc/custodia as an externally mounted volume in docker image

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN install -d -m 755 -o custodia -g custodia \
     /var/log/custodia \
     /var/run/custodia \
     /var/lib/custodia
-VOLUME ["/var/log/custodia", "/var/lib/custodia", "/var/run/custodia"]
+VOLUME ["/etc/custodia", "/var/log/custodia", "/var/lib/custodia", "/var/run/custodia"]
 
 # Copy default custodia conf
 COPY contrib/config/custodia.conf /etc/custodia/


### PR DESCRIPTION
The /etc/custodia directory should be an externally mounted volume
in our docker image.  Currently, /etc/custodia is a part of the
image itself.  This means that configuration changes will be stored
in the container using the union FS.  Configuration should be mounted
from the host itself, just like we do for the database and logs. This
will allow the container to be upgraded to a new image version without
losing the configuration changes.