### PR TITLE
Update docs to refer to RTD instead of wiki

### DIFF
--- a/README
+++ b/README
@@ -21,8 +21,8 @@ In future the Custodia project plans to enhance and enrich the API to
 provide access to even more secure means of dealing with private keys,
 like HSM as a Service and other similar security systems.
 
-See the Custodia wiki for more information about the current
-architecture: https://github.com/latchset/custodia/wiki
+See the Custodia documentation for more information:
+https://custodia.readthedocs.io
 
 Requirements
 ------------

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ In future the Custodia project plans to enhance and enrich the API to provide
 access to even more secure means of dealing with private keys, like HSM as a
 Service and other similar security systems.
 
-See the Custodia wiki for more information about the current architecture:
-https://github.com/latchset/custodia/wiki
+See the Custodia documentation for more information:
+https://custodia.readthedocs.io
 
 
 ## Requirements

--- a/docs/source/plugins/index.rst
+++ b/docs/source/plugins/index.rst
@@ -1,6 +1,60 @@
 Custodia Plugins
 ================
 
+Custodia is built as an HTTP based pipeline where each stage of the process is
+pluggable. The main stages are:
+
+  * Authentication
+  * Authorization
+  * Request handling
+  * Storage
+
+Plugin Stages
+-------------
+
+Authentication
+^^^^^^^^^^^^^^
+
+Authentication is handled by a stackable set of arbitrary plugins (python
+modules referenced in the configuration file). If any of the authentication
+plugins returns a negative answer the request is aborted with a 403 error. If
+any returns a positive answer then the request is allowed to proceed to the
+next phase. If none of the aplugins returns either a positive or negative
+answer the request fails, as by default access is denied.
+
+Authorization
+^^^^^^^^^^^^^
+
+Authorization is also handled by a stackable set of plugins, however in this
+case plugins are ordered. As soon as one plugin returns a positive or negative
+answer the request can pass to the next stage or is refused. If no plugin
+returns a positive or negative answer, the request is refused as access is
+denied by default.
+
+Request Handling
+^^^^^^^^^^^^^^^^
+
+Request handling is also pluggable and depends mostly on the path used in the
+request. Multiple handlers can be used, and each will be associated to a path.
+Handlers can be arbitrarily complex, custodia provides a default handler called
+'secrets', this handler can manage access to secrets using various request
+message types (currently simple or key-exchange-message).
+
+Storage
+^^^^^^^
+
+The storage in custodia is also pluggable and doesn't need to be an actual
+database or file system. It can as well be a chaining module that will call
+another Custodia instance up the chain, usually massaging the request path and
+the request headers to provide hints or authentication tokens to the upstream
+Custodia instance. This is very powerful and allows the infrastructure to
+partition the namespace and redirect requests to multiple sources, based on
+arbitrary rules, either for load balancing reasons, or in order to segregate
+different tenants to different storage systems.
+
+Plugin Modules
+--------------
+
 .. toctree::
    :maxdepth: 2
 

--- a/docs/source/readme.rst
+++ b/docs/source/readme.rst
@@ -20,8 +20,8 @@ In future the Custodia project plans to enhance and enrich the API to
 provide access to even more secure means of dealing with private keys,
 like HSM as a Service and other similar security systems.
 
-See the Custodia wiki for more information about the current
-architecture: https://github.com/latchset/custodia/wiki
+See the Custodia documentation for more information:
+https://custodia.readthedocs.io
 
 Requirements
 ------------


### PR DESCRIPTION
The information documented on the Custodia wiki is very minimal.
The only thing described there is the basic plugin architecture.
This patch moves the content from the wiki into the plugin section
of the in-tree docs.  Since these docs are built and published on
RTD, I've also updated our README files to refer to the RTD page
instead of the wiki.  These changes will allow us to get rid of
our wiki and just use RTD as the single official source of online
Custodia documentation.