### PR TITLE
Clean up API documentation

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -9,7 +9,7 @@ Authentication and authorization are fully pluggable and are therefore,
 not standardized.
 
 Access paths are also not standardized, although the common practice is
-to mount th secrets api under the /secrets URI
+to mount the secrets api under the /secrets URI.
 
 The Custodia API uses JSON to format requests and replies.
 
@@ -23,26 +23,26 @@ Simple
 
 Format: ``{ type: "simple", value: }``
 
-The Simple type is an arbitrary value holder. It is recommend but not
+The Simple type is an arbitrary value holder. It is recommended, but not
 required to base64 encode binary values or non-string values.
 
 The value must be representable as a valid JSON string. Keys are
-validated before being stored, unknown key types or invalid JSON values
+validated before being stored. Unknown key types or invalid JSON values
 are refused and an error is returned.
 
-NOTE: As an alternative it is possible to send a simple "raw" value by
+NOTE: As an alternative, it is possible to send a simple "raw" value by
 setting the Content-type of the request to "application/octet-stream".
-In this case the value will be base64 encoded when received and can be
+In this case, the value will be base64 encoded when received and can be
 accessed as a base64 encoded value in the JSON string when the default
-GET format is used. Sending the "Accept: application/octet-stream"
+GET operation is used. Sending the "Accept: application/octet-stream"
 header will instead cause the GET operation to return just the raw value
 that was originally sent.
 
 Key Exchange Message
 --------------------
 
-the Key Exchange Message format builds on the JSON Web Signature and the
-JSON Web Encryption specification to build respectively the request and
+The Key Exchange Message format builds on the JSON Web Signature and the
+JSON Web Encryption specifications to build respectively the request and
 reply messages. The aim is to provide the Custodia server the means to
 encrypt the reply to a client that proves possession of private key.
 
@@ -52,31 +52,36 @@ Format:
 - JSON Value for PUT/GET Reply: ``{"type:"kem","value":"Message"}``
 
 The Message for a GET is a JWT (JWS): (flattened/decoded here for
-clarity) ``{ "protected": { "kid": , "alg": "a valid alg name"}, "claims":
+clarity): ``{ "protected": { "kid": , "alg": "a valid alg name"}, "claims":
 { "sub": , "exp": , ["value": ]}, "signature": "XYZ...." }``
 
-Attributes: - public-key-identifier: This is the kid of a key that must
-be known to the Custodia service. If opportunistic encription is
-desired, and the requesting client is authenticated in other ways a
-"jku" header could be used instead, and a key fetched on the fly. This
-is not recommended for the gneral case and is not currently supported by
-the implementation. - name-of-secret: this repeates the name of the
-secret embedded in the GET, This is used to prevent substitution attacks
-where a client is intercepted and its signed request is reused to
-request a different key. - unix-timestamp: used to limit replay attacks,
-indicated expiration time, and should be no further than 5 minutes in
-the future, with leway up to 10 minutes to account for clock skews
-Additional claims may be present, for example a 'value'.
+Attributes:
+
+- public-key-identifier: This is the kid of a key that must
+  be known to the Custodia service. If opportunistic encryption is
+  desired and the requesting client is authenticated in other ways, a
+  "jku" header could be used instead and a key fetched on the fly. This
+  is not recommended for the gneral case and is not currently supported by
+  the implementation.
+- name-of-secret: this repeats the name of the secret embedded in the GET.
+  This is used to prevent substitution attacks where a client is intercepted
+  and its signed request is reused to request a different key.
+- unix-timestamp: used to limit replay attacks, indicated expiration time,
+  and should be no further than 5 minutes in the future, with leeway up to 10
+  minutes to account for clock skews.
+- Additional claims may be present, for example a 'value'.
 
 The Message for a GET reply or a PUT is a JWS Encoded message (see
 above) nested in a JWE Encoded message: (flattened/decoded here for
 clarity): ``{ "protected": { "kid": , "alg": "a valid alg name", "enc": "a
 valid enc type"}, "encrypted\_key": , "iv": , "ciphertext": , "tag": }``
 
-Attributes: - public-key-identifier: Must be the server public key
-identifier. reply (see above). Or the server public key for a PUT. - The
-inner JWS payload will typically contain a 'value' that is an arbitrary
-key. example: ``{ type: "simple", value: }``
+Attributes:
+
+- public-key-identifier: Must be the server public key identifier. reply (see
+  above). Or the server public key for a PUT.
+- The inner JWS payload will typically contain a 'value' that is an arbitrary
+  key. example: ``{ type: "simple", value: }``
 
 REST API
 ========
@@ -91,7 +96,7 @@ There are essentially 2 objects recognized by the API:
 
 Key containers can be nested and named arbitrarily, however depending on
 authorization schemes used the basic container is often named after a
-group or a user in order to make authorization chcks simpler.
+group or a user in order to make authorization checks simpler.
 
 Getting keys
 ------------
@@ -112,7 +117,7 @@ Returns:
 Storing keys
 ------------
 
-A PUT operation withthe name of the key: PUT ``/secrets/name/of/key``
+A PUT operation with the name of the key: ``PUT /secrets/name/of/key``
 
 The Content-Type MUST be 'application/json' The Content-Length MUST be
 specified, and the body MUST be a key in one of the valid formats
@@ -120,7 +125,7 @@ described above.
 
 Returns:
 
-- 201 in case of success.
+- 201 in case of success
 - 400 if the request format is invalid
 - 401 if authentication is necessary
 - 403 if access to the key is forbidden
@@ -136,7 +141,7 @@ A DELETE operation with the name of the key: ``DELETE /secrets/name/of/key``
 
 Returns:
 
-- 204 in case of success.
+- 204 in case of success
 - 401 if authentication is necessary
 - 403 if access to the key is forbidden
 - 404 if no key was found
@@ -146,14 +151,15 @@ Listing containers
 ------------------
 
 A GET operation on a path that ends in a '/' translates into a listing
-for a container. ``GET /secrets/container/``
+for a container: ``GET /secrets/container/``
 
 Implementations may assume a default container if none is excplicitly
 provided: GET /secrets/ may return only keys under //\*
 
 Returns:
 
-- 200 in case of success and a dictionary containing a list of all keys in the container and all subcontainers.
+- 200 in case of success and a dictionary containing a list of all keys
+  in the container and all subcontainers
 - 401 if authentication is necessary
 - 403 if access to the key is forbidden
 - 404 if no key was found
@@ -169,7 +175,7 @@ Default containers may be automatically created by an implementation.
 
 Returns:
 
-- 201 in case of success.
+- 201 in case of success
 - 400 if the request format is invalid
 - 401 if authentication is necessary
 - 403 if access to the key is forbidden
@@ -184,7 +190,7 @@ A DELETE operation with the name of the container: ``DELETE /secrets/mycontainer
 
 Returns:
 
-- 204 in case of success.
+- 204 in case of success
 - 401 if authentication is necessary
 - 403 if access to the container is forbidden
 - 404 if no container was found


### PR DESCRIPTION
This cleans up a number of formatting and typo issues in the API
documentation.