### PR TITLE
Warn users about missing systemd bindings

### DIFF
--- a/custodia/httpd/server.py
+++ b/custodia/httpd/server.py
@@ -9,6 +9,7 @@ import socket
 import ssl
 import struct
 import sys
+import warnings
 
 import six
 
@@ -25,10 +26,21 @@ except ImportError:
     from urllib.parse import urlparse, parse_qs, unquote
 
 try:
-    # pylint: disable=import-error
-    from systemd import daemon as sd
+    from systemd import daemon as sd  # pylint: disable=import-error
 except ImportError:
     sd = None
+    if 'NOTIFY_SOCKET' in os.environ:
+        warnings.warn(
+            "NOTIFY_SOCKET env var is set but python-systemd bindings are "
+            "not available!",
+            category=RuntimeWarning
+        )
+    if 'LISTEN_FDS' in os.environ:
+        warnings.warn(
+            "LISTEN_FDS env var is set, but python-systemd bindings are"
+            "not available!",
+            category=RuntimeWarning
+        )
 
 
 from custodia import log


### PR DESCRIPTION
Python systemd bindings are an optional component. Custodia used to
silently ignore systemd features like sd_notify and sd_listen_fds, when
the bindings could not be imported.

Now Custodia prints a warning when it detects NOTIFY_SOCKET or
LISTEN_FDS env vars.

Signed-off-by: Christian Heimes <cheimes@redhat.com>