### PR TITLE
SimpleCredsAuth: Don't hard-code uid/gid defaults to 0

### DIFF
--- a/custodia/httpd/authenticators.py
+++ b/custodia/httpd/authenticators.py
@@ -9,17 +9,19 @@ from custodia.plugin import HTTPAuthenticator, PluginOption
 
 
 class SimpleCredsAuth(HTTPAuthenticator):
-    uid = PluginOption('pwd_uid', 0, "User id or name")
-    gid = PluginOption('grp_gid', 0, "Group id or name")
+    uid = PluginOption('pwd_uid', -1, "User id or name, -1 ignores user")
+    gid = PluginOption('grp_gid', -1, "Group id or name, -1 ignores group")
 
     def handle(self, request):
         creds = request.get('creds')
         if creds is None:
             self.logger.debug('SCA: Missing "creds" from request')
             return False
-        uid = int(creds['gid'])
-        gid = int(creds['uid'])
-        if self.gid == gid or self.uid == uid:
+        uid = int(creds['uid'])
+        gid = int(creds['gid'])
+        uid_match = self.uid != -1 and self.uid == uid
+        gid_match = self.gid != -1 and self.gid == gid
+        if uid_match or gid_match:
             self.audit_svc_access(log.AUDIT_SVC_AUTH_PASS,
                                   request['client_id'],
                                   "%d, %d" % (uid, gid))

--- a/tests/test_authenticators.py
+++ b/tests/test_authenticators.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 import configparser
 
 import grp
-import os
 import pwd
 import unittest
 
@@ -55,10 +54,12 @@ value = admin user
 class TestAuthenticators(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.user = user = pwd.getpwuid(os.getuid())
+        # Tests are depending on two existing and distinct users and groups.
+        # We chose 'root' with uid/gid 0 and 'nobody', because both exist on
+        # all relevant platforms. Tests use a mocked request so they run
+        # under any user.
+        cls.user = user = pwd.getpwnam('nobody')
         cls.group = group = grp.getgrgid(user.pw_gid)
-        if cls.user.pw_uid == 0 or cls.group.gr_gid == 0:
-            raise ValueError("Don't run tests as root!")
 
         cls.parser = configparser.ConfigParser(
             interpolation=configparser.ExtendedInterpolation(),


### PR DESCRIPTION
The SimpleCredsAuth plugin used to hard-code default uid and default gid
as 0. The new default values are '-1', which means "don't match".

Closes: #116
Signed-off-by: Christian Heimes <cheimes@redhat.com>