### PR TITLE
Coverage: run in parallel and report after tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ cscope.out
 .tox
 .cache
 .coverage
+.coverage.*
 MANIFEST
 custodia.audit.log
 secrets.db

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,14 @@ matrix:
       env: TOXENV=pep8py3
 
 install:
-  - pip install --upgrade pip setuptools
+  - pip install --upgrade pip setuptools codecov
   - pip --version
   - pip install tox
   - tox --version
 
 script:
   - tox
+
+after_success:
+  - python -m coverage combine
+  - codecov

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ all: clean_socket lint pep8 test docs
 clean_socket:
 	rm -f $(SERVER_SOCKET) $(CONTAINER_SOCKET)
 
+clean_coverage:
+	rm -f .coverage .coverage.*
+
 lint: clean_socket
 	$(TOX) -e lint
 
@@ -40,8 +43,8 @@ pep8: clean_socket
 	$(TOX) -e pep8py2
 	$(TOX) -e pep8py3
 
-clean: clean_socket
-	rm -fr build dist *.egg-info .tox MANIFEST .coverage .cache
+clean: clean_socket clean_coverage
+	rm -fr build dist *.egg-info .tox MANIFEST .cache
 	rm -f custodia.audit.log secrets.db
 	rm -rf docs/build
 	find ./ -name '*.py[co]' -exec rm -f {} \;
@@ -52,12 +55,13 @@ clean: clean_socket
 cscope:
 	git ls-files | xargs pycscope
 
-test: clean_socket
-	rm -f .coverage
+test: clean_socket clean_coverage
 	$(TOX) --skip-missing-interpreters -e py27
 	$(TOX) --skip-missing-interpreters -e py34
 	$(TOX) --skip-missing-interpreters -e py35
+	$(TOX) --skip-missing-interpreters -e py36
 	$(TOX) --skip-missing-interpreters -e doc
+	$(TOX) -e coverage-report
 
 README: README.md
 	echo -e '.. WARNING: AUTO-GENERATED FILE. DO NOT EDIT.\n' > $@

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.3.1
-envlist = lint,py27,py34,py35,py36,pep8py2,pep8py3,doc,sphinx
+envlist = lint,py27,py34,py35,py36,pep8py2,pep8py3,doc,sphinx,coverage-report
 skip_missing_interpreters = true
 
 [testenv]
@@ -11,9 +11,15 @@ deps =
 # Makefile and RPM spec set sitepackages=True
 sitepackages = False
 commands =
-    {envpython} -m coverage run --append \
+    {envpython} -m coverage run --parallel \
         -m pytest --capture=no --strict {posargs}
-    {envpython} -m coverage report -m
+
+[testenv:coverage-report]
+deps = coverage
+skip_install = true
+commands =
+    {envpython} -m coverage combine
+    {envpython} -m coverage report
 
 [testenv:lint]
 basepython = python2.7


### PR DESCRIPTION
Instead of reporting after each test run, tox now reports a combined
coverage report for all tested Python versions.

https://hynek.me/articles/testing-packaging/

Signed-off-by: Christian Heimes <cheimes@redhat.com>