### PR TITLE
Move Py2/Py3 imports to custodia.compat

### DIFF
--- a/custodia/compat.py
+++ b/custodia/compat.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+"""Python 2/3 compatibility
+"""
+# pylint: disable=no-name-in-module,import-error
+import six
+
+
+if six.PY2:
+    # use https://pypi.python.org/pypi/configparser/ on Python 2
+    from backports import configparser
+    from urllib import quote as url_escape
+    from urllib import quote_plus, unquote
+    from urlparse import parse_qs, urlparse
+else:
+    import configparser
+    from urllib.parse import quote as url_escape
+    from urllib.parse import parse_qs, quote_plus, unquote, urlparse
+
+
+__all__ = (
+    'configparser',
+    'parse_qs', 'quote_plus', 'unquote', 'url_escape', 'urlparse'
+)

--- a/custodia/httpd/server.py
+++ b/custodia/httpd/server.py
@@ -13,17 +13,18 @@ import warnings
 
 import six
 
-try:
-    # pylint: disable=import-error
+from custodia import log
+from custodia.compat import parse_qs, unquote, urlparse
+from custodia.plugin import HTTPError
+
+# pylint: disable=import-error,no-name-in-module
+if six.PY2:
     from BaseHTTPServer import BaseHTTPRequestHandler
     from SocketServer import ForkingTCPServer, BaseServer
-    from urlparse import urlparse, parse_qs
-    from urllib import unquote
-except ImportError:
-    # pylint: disable=import-error,no-name-in-module
+else:
     from http.server import BaseHTTPRequestHandler
     from socketserver import ForkingTCPServer, BaseServer
-    from urllib.parse import urlparse, parse_qs, unquote
+# pylint: enable=import-error,no-name-in-module
 
 try:
     from systemd import daemon as sd  # pylint: disable=import-error
@@ -42,9 +43,6 @@ except ImportError:
             category=RuntimeWarning
         )
 
-
-from custodia import log
-from custodia.plugin import HTTPError
 
 logger = logging.getLogger(__name__)
 

--- a/custodia/plugin.py
+++ b/custodia/plugin.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2016  Custodia Project Contributors - see LICENSE file
 
 import abc
-import configparser
 import grp
 import inspect
 import json
@@ -14,6 +13,7 @@ from jwcrypto.common import json_encode
 
 import six
 
+from .compat import configparser
 from .log import auditlog
 
 

--- a/custodia/server/__init__.py
+++ b/custodia/server/__init__.py
@@ -1,24 +1,17 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
-try:
-    # pylint: disable=import-error
-    from urllib import quote as url_escape
-except ImportError:
-    # pylint: disable=no-name-in-module,import-error
-    from urllib.parse import quote as url_escape
 import argparse
 import importlib
 import logging
 import os
 import socket
 
-# use https://pypi.python.org/pypi/configparser/ on Python 2
-from configparser import ConfigParser, ExtendedInterpolation
-
 import pkg_resources
 
 import six
 
 from custodia import log
+from custodia.compat import configparser
+from custodia.compat import url_escape
 from custodia.httpd.server import HTTPServer
 
 
@@ -107,8 +100,8 @@ def parse_config(args):
         'hostname': socket.gethostname(),
     }
 
-    parser = ConfigParser(
-        interpolation=ExtendedInterpolation(),
+    parser = configparser.ConfigParser(
+        interpolation=configparser.ExtendedInterpolation(),
         defaults=defaults
     )
     parser.optionxform = str

--- a/docs/source/examples/cfgparser.py
+++ b/docs/source/examples/cfgparser.py
@@ -2,14 +2,14 @@
 
 import collections
 import json
-from configparser import ConfigParser, ExtendedInterpolation, SectionProxy
 
 from custodia.client import CustodiaSimpleClient
+from custodia.compat import configparser
 
 from requests.exceptions import HTTPError
 
 
-class CustodiaSectionProxy(SectionProxy):
+class CustodiaSectionProxy(configparser.SectionProxy):
     """A section proxy that supports getsecret()
     """
     def getsecret(self, option, fallback=None, **kwargs):
@@ -45,7 +45,7 @@ class CustodiaMapping(collections.Mapping):
         return {}.__iter__()
 
 
-class CustodiaConfigParser(ConfigParser):
+class CustodiaConfigParser(configparser.ConfigParser):
     """Python 3 like config parser with Custodia support.
 
     Example config::
@@ -65,7 +65,7 @@ class CustodiaConfigParser(ConfigParser):
     or loaded from the [custodia_client] section.
 
     """
-    _DEFAULT_INTERPOLATION = ExtendedInterpolation()
+    _DEFAULT_INTERPOLATION = configparser.ExtendedInterpolation()
     custodia_client_section = 'custodia_client'
     custodia_section = 'CUSTODIA'
 

--- a/tests/test_authenticators.py
+++ b/tests/test_authenticators.py
@@ -2,12 +2,11 @@
 
 from __future__ import absolute_import
 
-import configparser
-
 import grp
 import pwd
 import unittest
 
+from custodia.compat import configparser
 from custodia.httpd import authenticators
 
 CONFIG = u"""

--- a/tests/test_custodia.py
+++ b/tests/test_custodia.py
@@ -2,7 +2,6 @@
 
 from __future__ import absolute_import
 
-import configparser
 import os
 import shutil
 import socket
@@ -11,13 +10,6 @@ import sys
 import time
 import unittest
 from string import Template
-
-try:
-    # pylint: disable=import-error
-    from urllib import quote_plus
-except ImportError:
-    # pylint: disable=import-error,no-name-in-module
-    from urllib.parse import quote_plus
 
 from jwcrypto import jwk
 
@@ -28,6 +20,7 @@ from requests.exceptions import HTTPError, SSLError
 import six
 
 from custodia.client import CustodiaKEMClient, CustodiaSimpleClient
+from custodia.compat import configparser, quote_plus
 from custodia.store.sqlite import SqliteStore
 
 

--- a/tests/test_message_kem.py
+++ b/tests/test_message_kem.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
 
-import configparser
 import os
 import time
 import unittest
@@ -11,6 +10,7 @@ from jwcrypto.jwk import JWK
 from jwcrypto.jws import JWS
 from jwcrypto.jwt import JWT
 
+from custodia.compat import configparser
 from custodia.message import kem
 from custodia.store.sqlite import SqliteStore
 

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
 
-import configparser
 import logging
 import os
 import unittest
@@ -8,6 +7,7 @@ import unittest
 from base64 import b64encode
 
 from custodia import log
+from custodia.compat import configparser
 from custodia.httpd.authorizers import UserNameSpace
 from custodia.plugin import HTTPError
 from custodia.secrets import Secrets

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,12 +1,12 @@
 # Copyright (C) 2016  Custodia Project Contributors - see LICENSE file
 from __future__ import print_function
 
-import configparser
 import os
 import shutil
 import tempfile
 import unittest
 
+from custodia.compat import configparser
 from custodia.plugin import CSStoreError
 from custodia.store.encgen import EncryptedOverlay
 from custodia.store.sqlite import SqliteStore

--- a/tests/test_store_sqlite.py
+++ b/tests/test_store_sqlite.py
@@ -1,11 +1,11 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
 from __future__ import print_function
 
-import configparser
 import shutil
 import tempfile
 import unittest
 
+from custodia.compat import configparser
 from custodia.plugin import CSStoreExists
 from custodia.store.sqlite import SqliteStore
 


### PR DESCRIPTION
A new module custodia.compat now contains all imports that are different
between Python 2 and 3. It simplifies vendoring of configparser, too.

Of course there is no rule without exception. Since HTTP and socket
servers are only used by the server, imports stay in the HTTP server
module. There is no point to slow down custodia-cli with unnecessasry
imports.

Signed-off-by: Christian Heimes <cheimes@redhat.com>