### PR TITLE
Replace path with tuple of unquoted path segments

### DIFF
--- a/custodia/server/__init__.py
+++ b/custodia/server/__init__.py
@@ -161,7 +161,10 @@ def parse_config(args):
 
         if s.startswith('/'):
             menu = 'consumers'
-            name = s
+            path_chain = s.split('/')
+            if path_chain[-1] == '':
+                path_chain = path_chain[:-1]
+            name = tuple(path_chain)
         else:
             if s.startswith('auth:'):
                 menu = 'authenticators'

--- a/tests/test_custodia.py
+++ b/tests/test_custodia.py
@@ -392,6 +392,26 @@ class CustodiaTests(unittest.TestCase):
         except HTTPError:
             self.assertEqual(self.kem.last_response.status_code, 404)
 
+    def test_B_1_kem_space(self):
+        self.kem.create_container('kem')
+        cl = self.kem.list_container('kem')
+        self.assertEqual(cl, [])
+        self.kem.set_secret('kem/key with space', 'Protected Space')
+        cl = self.kem.list_container('kem')
+        self.assertEqual(cl, ['key with space'])
+        value = self.kem.get_secret('kem/key with space')
+        self.assertEqual(value, 'Protected Space')
+        self.kem.del_secret('kem/key with space')
+        try:
+            self.kem.get_secret('kem/key with space')
+        except HTTPError:
+            self.assertEqual(self.kem.last_response.status_code, 404)
+        self.kem.delete_container('kem')
+        try:
+            self.kem.list_container('kem')
+        except HTTPError:
+            self.assertEqual(self.kem.last_response.status_code, 404)
+
 
 class CustodiaHTTPSTests(CustodiaTests):
     socket_url = 'https://localhost:{}'.format(find_port())

--- a/tests/test_custodia.py
+++ b/tests/test_custodia.py
@@ -305,11 +305,11 @@ class CustodiaTests(unittest.TestCase):
 
     def test_3_list_container(self):
         cl = self.client.list_container('test')
-        self.assertEqual(cl, ["cli", "http%3A%2F%2Flocalhost%3A5000", "key"])
+        self.assertEqual(cl, ["cli", "http://localhost:5000", "key"])
 
     def test_3_list_container_cli(self):
         cl = self._custoda_cli('ls', 'test', split=True)
-        self.assertEqual(cl, ["cli", "http%3A%2F%2Flocalhost%3A5000", "key"])
+        self.assertEqual(cl, ["cli", "http://localhost:5000", "key"])
 
     def test_4_del_simple_key(self):
         self.client.del_secret('test/key')


### PR DESCRIPTION
The old path handling code used a string of '/' separated path segments.
This was causing trouble with unquoted of %2F (quoted slash).

A new request parameter 'path_chain' contains a tuple of unquoted path
segments. Since / is no longer used as path separator inside the path,
quoted slash can be safely used.

The old path argument is still available until all plugins have been ported.

Closes: #135
Signed-off-by: Christian Heimes <cheimes@redhat.com>