### PR TITLE
Improvement in the error reporting message

### DIFF
--- a/custodia/cli/__init__.py
+++ b/custodia/cli/__init__.py
@@ -15,6 +15,8 @@ except ImportError:
 
 import pkg_resources
 
+
+from requests.exceptions import ConnectionError
 from requests.exceptions import HTTPError as RequestsHTTPError
 
 from custodia import log
@@ -204,11 +206,14 @@ def main():
     if args.certfile:
         args.client_conn.set_client_cert(args.certfile, args.keyfile)
         args.client_conn.headers['CUSTODIA_CERT_AUTH'] = 'true'
-
     try:
         result = args.func(args)
     except RequestsHTTPError as e:
         return main_parser.exit(1, str(e))
+    except ConnectionError:
+        connection_error_msg = "Unable to connect to the server via " \
+                               "{}".format(args.server)
+        return main_parser.exit(2, connection_error_msg)
     except Exception as e:  # pylint: disable=broad-except
         if args.verbose:
             traceback.print_exc(file=sys.stderr)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,24 @@ class TestsCommandLine(unittest.TestCase):
         output = self._custodia_cli('--help')
         self.assertIn(u'Custodia command line interface', output)
 
+    def test_connection_error_with_server_option(self):
+        invalid_server_name = 'http://custodia.invalid/secrets/key'
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self._custodia_cli('--server',
+                               invalid_server_name,
+                               'ls',
+                               '/')
+        self.assertIn(invalid_server_name, cm.exception.output)
+
+    def test_connection_error_with_uds_urlpath_option(self):
+        invalid_path_name = 'path/to/file'
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self._custodia_cli('--uds-urlpath',
+                               invalid_path_name,
+                               'ls',
+                               '/')
+        self.assertIn(invalid_path_name, cm.exception.output)
+
     def test_plugins(self):
         output = self._custodia_cli('plugins')
         self.assertIn(u'[custodia.authenticators]', output)


### PR DESCRIPTION
In case Custodia is down or not responding, custodia-cli
just fails with a raw connection exception like
('Connection aborted.', error(104, 'Connection reset by peer')).
Adding a more user-friendly error message containing the
socket endpoint.

Closes: #131
Signed-off-by: Raildo Mascena <rmascena@redhat.com>