### PR TITLE
Fix test flapping due to DNS resolution

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,7 +41,7 @@ class TestsCommandLine(unittest.TestCase):
         self.assertIn(u'Custodia command line interface', output)
 
     def test_connection_error_with_server_option(self):
-        invalid_server_name = 'http://custodia.invalid/secrets/key'
+        invalid_server_name = 'http://localhost:4/secrets/key'
         with self.assertRaises(subprocess.CalledProcessError) as cm:
             self._custodia_cli('--server',
                                invalid_server_name,


### PR DESCRIPTION
Using an actual DNS name sometimes causes the test to fail with error
dependent on resolution.
Given this test is meant to check for connection errors and not for name
resolution errors, change the name to use localhost and an unassigned
low TCP port so we get always a connection refused error.