### PR TITLE
Log plugin load traceback in debug mode

### DIFF
--- a/custodia/server/__init__.py
+++ b/custodia/server/__init__.py
@@ -188,6 +188,7 @@ def _load_plugins(config, parser):
         try:
             config[menu][name] = _create_plugin(parser, s, menu)
         except Exception as e:
+            logger.debug("Plugin '%s' failed to load.", name, exc_info=True)
             raise RuntimeError(menu, name, e)
 
     # Attach stores to other plugins


### PR DESCRIPTION
Make it a bit easier to diagnose a plugin configuration exception.

Signed-off-by: Christian Heimes <cheimes@redhat.com>