### PR TITLE
Distigish between a subcontainer and keys under a container

### DIFF
--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -337,3 +337,50 @@ class SecretsTests(unittest.TestCase):
         self.assertEqual(rep['output'],
                          {"type": "simple", "value":
                           b64encode(b'1234').decode('utf-8')})
+
+    def test_10_LIST_subcontainer_and_keys(self):
+        # Create a container
+        req = {'remote_user': 'test',
+               'trail': ['test', 'container_a', '']}
+        rep = {'headers': {}}
+        self.POST(req, rep)
+        self.assertEqual(rep['code'], 201)
+
+        # Create a subcontainer over the parent container
+        req = {'remote_user': 'test',
+               'trail': ['test', 'container_a', 'subcontainer', '']}
+        rep = {'headers': {}}
+        self.POST(req, rep)
+        self.assertEqual(rep['code'], 201)
+
+        # Create a secret over the parent container
+        req = {'headers': {'Content-Type': 'application/json'},
+               'remote_user': 'test',
+               'trail': ['test', 'container_a', 'key2'],
+               'body': '{"type":"simple","value":"1234"}'.encode('utf-8')}
+        rep = {}
+        self.PUT(req, rep)
+
+        # Retrieve the container_a data
+        req = {'remote_user': 'test',
+               'trail': ['test', 'container_a', '']}
+        rep = {'headers': {}}
+        self.GET(req, rep)
+        # Verify that we can now distigish between a subcontainer
+        # and a key
+        self.assertEqual(rep['output'], ['key2', 'subcontainer/'])
+        # Clean up
+        req = {'remote_user': 'test',
+               'trail': ['test', 'container_a', 'key2']}
+        self.DELETE(req, rep)
+        self.assertEqual(rep['code'], 204)
+
+        req = {'remote_user': 'test',
+               'trail': ['test', 'container_a', 'subcontainer', '']}
+        self.DELETE(req, rep)
+        self.assertEqual(rep['code'], 204)
+
+        req = {'remote_user': 'test',
+               'trail': ['test', 'container_a', '']}
+        self.DELETE(req, rep)
+        self.assertEqual(rep['code'], 204)

--- a/tests/test_store_sqlite.py
+++ b/tests/test_store_sqlite.py
@@ -116,9 +116,9 @@ class SqliteStoreTests(unittest.TestCase):
         self.store.span('/span/2')
         self.store.span('/span/2/span')
         value = self.store.list('/span')
-        self.assertEqual(value, ['2', '2/span'])
+        self.assertEqual(value, ['2/', '2/span/'])
         value = self.store.list('/span/2')
-        self.assertEqual(value, ['span'])
+        self.assertEqual(value, ['span/'])
         value = self.store.list('/span/2/span')
         self.assertEqual(value, [])
 


### PR DESCRIPTION
When we list a container returns subcontainers without a following '/'
which makes hard to distiguish between other keys under this container.
On the list container, we should add a '/' after a subcontainer.

Signed-off-by: Raildo Mascena <rmascena@redhat.com>