### PR TITLE
Fix pylint warnings

### DIFF
--- a/custodia/cli/__main__.py
+++ b/custodia/cli/__main__.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2016  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 from custodia.cli import main
 

--- a/custodia/client.py
+++ b/custodia/client.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 import logging
 import socket

--- a/custodia/compat.py
+++ b/custodia/compat.py
@@ -2,6 +2,8 @@
 """Python 2/3 compatibility
 """
 # pylint: disable=no-name-in-module,import-error
+from __future__ import absolute_import
+
 import six
 
 

--- a/custodia/forwarder.py
+++ b/custodia/forwarder.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 import uuid
 
@@ -25,6 +26,7 @@ class Forwarder(HTTPConsumer):
             self.client.set_ca_cert(self.tls_cafile)
         self.uuid = str(uuid.uuid4())
         # pylint: disable=unsubscriptable-object
+        # pylint: disable=unsupported-assignment-operation
         self.forward_headers['X-LOOP-CUSTODIA'] = self.uuid
 
     def _path(self, request):

--- a/custodia/httpd/authenticators.py
+++ b/custodia/httpd/authenticators.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 import os
 

--- a/custodia/httpd/authorizers.py
+++ b/custodia/httpd/authorizers.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 import os
 

--- a/custodia/httpd/consumer.py
+++ b/custodia/httpd/consumer.py
@@ -1,4 +1,6 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
+
 import warnings
 
 from custodia.plugin import DEFAULT_CTYPE, HTTPConsumer, SUPPORTED_COMMANDS

--- a/custodia/httpd/server.py
+++ b/custodia/httpd/server.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 import atexit
 import errno
@@ -259,8 +260,8 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
             return None
         return self.request.getpeercert()
 
-    def parse_request(self, *args, **kwargs):
-        if not BaseHTTPRequestHandler.parse_request(self, *args, **kwargs):
+    def parse_request(self):
+        if not BaseHTTPRequestHandler.parse_request(self):
             return False
 
         # grab the loginuid from `/proc` as soon as possible
@@ -385,6 +386,7 @@ class HTTPRequestHandler(BaseHTTPRequestHandler):
             self.close_connection = 1
             return
 
+    # pylint: disable=arguments-differ
     def log_error(self, fmtstr, *args, **kwargs):
         logger.error(fmtstr, *args, **kwargs)
 

--- a/custodia/log.py
+++ b/custodia/log.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 import logging
 import sys

--- a/custodia/message/common.py
+++ b/custodia/message/common.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 import logging
 

--- a/custodia/message/formats.py
+++ b/custodia/message/formats.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 from custodia.message.common import InvalidMessage
 from custodia.message.common import UnallowedMessage

--- a/custodia/message/kem.py
+++ b/custodia/message/kem.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 import logging
 import os

--- a/custodia/message/simple.py
+++ b/custodia/message/simple.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 from six import string_types
 

--- a/custodia/plugin.py
+++ b/custodia/plugin.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2016  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 import abc
 import grp
@@ -80,7 +81,7 @@ class OptionHandler(object):
         if handler is None:
             raise ValueError(typ)
         self.seen.add(name)
-        return handler(name, default)
+        return handler(name, default)  # pylint: disable=not-callable
 
     def check_surplus(self):
         surplus = []

--- a/custodia/root.py
+++ b/custodia/root.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 import json
 

--- a/custodia/secrets.py
+++ b/custodia/secrets.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 import json
 import os

--- a/custodia/server/__init__.py
+++ b/custodia/server/__init__.py
@@ -1,4 +1,6 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
+
 import argparse
 import importlib
 import logging

--- a/custodia/server/__main__.py
+++ b/custodia/server/__main__.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 from custodia.server import main
 

--- a/custodia/store/encgen.py
+++ b/custodia/store/encgen.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 import os
 

--- a/custodia/store/enclite.py
+++ b/custodia/store/enclite.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 from jwcrypto.common import json_decode, json_encode
 from jwcrypto.jwe import JWE

--- a/custodia/store/etcdstore.py
+++ b/custodia/store/etcdstore.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
-
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 try:
     from etcd import (Client, EtcdException, EtcdNotFile, EtcdAlreadyExist,

--- a/custodia/store/interface.py
+++ b/custodia/store/interface.py
@@ -1,4 +1,6 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
+
 import warnings
 
 from custodia.plugin import CSStore, CSStoreError, CSStoreExists

--- a/custodia/store/sqlite.py
+++ b/custodia/store/sqlite.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 import os
 import sqlite3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 # Copyright (C) 2016  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
+
 import warnings
 
 import pytest

--- a/tests/test_authenticators.py
+++ b/tests/test_authenticators.py
@@ -1,5 +1,4 @@
 # Copyright (C) 2016  Custodia Project Contributors - see LICENSE file
-
 from __future__ import absolute_import
 
 import grp

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 import os
 import socket

--- a/tests/test_custodia.py
+++ b/tests/test_custodia.py
@@ -1,5 +1,4 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
-
 from __future__ import absolute_import
 
 import os

--- a/tests/test_message_kem.py
+++ b/tests/test_message_kem.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 import os
 import time

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,4 +1,6 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
+
 import pkg_resources
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2016  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 import unittest
 

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
 
 import logging
 import os

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,4 +1,6 @@
 # Copyright (C) 2016  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
+
 from __future__ import print_function
 
 import os

--- a/tests/test_store_sqlite.py
+++ b/tests/test_store_sqlite.py
@@ -1,4 +1,6 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
+
 from __future__ import print_function
 
 import shutil


### PR DESCRIPTION
The latest version of pylint has introduced new checkers. Most warnings
can be silenced by enforcing absolute imports under Python 2.7.

Signed-off-by: Christian Heimes <cheimes@redhat.com>