### PR TITLE
Logging cleanup

### DIFF
--- a/custodia/cli/__init__.py
+++ b/custodia/cli/__init__.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, print_function
 
 import argparse
-import logging
 import operator
 import os
 import traceback
@@ -249,13 +248,10 @@ def error_message(args, exc):
 def main():
     args = main_parser.parse_args()
 
+    log.setup_logging(debug=args.debug, auditfile=None)
+
     if args.debug:
         args.verbose = True
-        logdict = logging.Logger.manager.loggerDict
-        for obj in logdict.values():
-            if not isinstance(obj, logging.Logger):
-                continue
-            obj.setLevel(logging.DEBUG)
 
     if args.server.startswith('http+unix://'):
         # append uds-path

--- a/custodia/client.py
+++ b/custodia/client.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
 from __future__ import absolute_import
 
-import logging
+
 import socket
 
 from jwcrypto.common import json_decode
@@ -15,11 +15,13 @@ from requests.compat import unquote, urlparse
 from requests.packages.urllib3.connection import HTTPConnection
 from requests.packages.urllib3.connectionpool import HTTPConnectionPool
 
+from custodia.log import getLogger
 from custodia.message.kem import (
     check_kem_claims, decode_enc_kem, make_enc_kem
 )
 
-logger = logging.getLogger(__name__)
+
+logger = getLogger(__name__)
 
 
 class HTTPUnixConnection(HTTPConnection):

--- a/custodia/httpd/server.py
+++ b/custodia/httpd/server.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 
 import atexit
 import errno
-import logging
 import os
 import shutil
 import socket
@@ -45,7 +44,7 @@ except ImportError:
         )
 
 
-logger = logging.getLogger(__name__)
+logger = log.getLogger(__name__)
 
 SO_PEERCRED = getattr(socket, 'SO_PEERCRED', 17)
 SO_PEERSEC = getattr(socket, 'SO_PEERSEC', 31)

--- a/custodia/log.py
+++ b/custodia/log.py
@@ -5,8 +5,8 @@ import logging
 import sys
 import warnings
 
-custodia_logger = logging.getLogger('custodia')
-custodia_logger.addHandler(logging.NullHandler())
+
+import six
 
 
 LOGGING_FORMAT = "%(asctime)s - %(origin)-32s - %(message)s"
@@ -14,6 +14,8 @@ LOGGING_DATEFORMAT = "%Y-%m-%d %H:%M:%S"
 
 
 class OriginContextFilter(logging.Filter):
+    """Context filter to include 'origin' attribute in record
+    """
     def filter(self, record):
         if not hasattr(record, 'origin'):
             record.origin = record.name.split('.')[-1]
@@ -21,21 +23,87 @@ class OriginContextFilter(logging.Filter):
         return True
 
 
-def setup_logging(debug=False, auditfile='custodia.audit.log'):
-    # prevent multiple stream handlers
-    root_logger = logging.getLogger()
-    if not any(isinstance(hdlr, logging.StreamHandler)
-               for hdlr in root_logger.handlers):
-        default_fmt = logging.Formatter(LOGGING_FORMAT, LOGGING_DATEFORMAT)
-        stream_hdlr = logging.StreamHandler(sys.stderr)
-        stream_hdlr.setFormatter(default_fmt)
-        stream_hdlr.addFilter(OriginContextFilter())
-        root_logger.addHandler(stream_hdlr)
+class CustodiaFormatter(logging.Formatter):
+    def format(self, record):
+        # customize record.exc_text, Formatter.format() does not modify
+        # exc_text when it has been set before.
+        short_exc = False
+        if record.exc_info and not record.exc_text:
+            if getattr(record, "exc_fullstack", True):
+                record.exc_text = self.formatException(record.exc_info)
+            else:
+                short_exc = True
+                record.exc_text = u"{0.__name__}: {1}".format(
+                    record.exc_info[0], record.exc_info[1]
+                )
 
+        result = super(CustodiaFormatter, self).format(record)
+        if short_exc:
+            # format() adds \n between message and exc_text
+            text, exc = result.rsplit(u'\n', 1)
+            return u"{0} ({1})".format(text, exc)
+        else:
+            return result
+
+
+class CustodiaLoggingAdapter(logging.LoggerAdapter):
+    def __init__(self, plugin, debug):
+        logger = logging.getLogger(
+            '{0.__class__.__module__}.{0.__class__.__name__}'.format(plugin)
+        )
+        logger.setLevel(logging.DEBUG if debug else logging.INFO)
+        extra = {'origin': plugin.origin}
+        super(CustodiaLoggingAdapter, self).__init__(logger, extra=extra)
+
+    def exception(self, msg, *args, **kwargs):
+        """Like standard exception() logger but only print stack in debug mode
+        """
+        extra = kwargs.setdefault('extra', {})
+        extra['exc_fullstack'] = self.isEnabledFor(logging.DEBUG)
+        kwargs['exc_info'] = True
+        self.log(logging.ERROR, msg, *args, **kwargs)
+
+
+def getLogger(name):
+    """Create logger with custom exception() method
+    """
+    def exception(self, msg, *args, **kwargs):
+        extra = kwargs.setdefault('extra', {})
+        extra['exc_fullstack'] = self.isEnabledFor(logging.DEBUG)
+        kwargs['exc_info'] = True
+        self.log(logging.ERROR, msg, *args, **kwargs)
+
+    logger = logging.getLogger(name)
+    logger.exception = six.create_bound_method(exception, logger)
+    return logger
+
+
+def setup_logging(debug=False, auditfile=None, handler=None):
+    root_logger = logging.getLogger()
+    # default is stream handler to stderr
+    if handler is None:
+        handler = logging.StreamHandler(sys.stderr)
+
+    # remove handler instance from root handler to prevent multiple
+    # output handlers.
+    handler_cls = type(handler)
+    root_logger.handlers[:] = list(
+        isinstance(h, handler_cls) for h in root_logger.handlers
+    )
+
+    # configure handler
+    handler.setFormatter(CustodiaFormatter(
+        fmt=LOGGING_FORMAT, datefmt=LOGGING_DATEFORMAT
+    ))
+    handler.addFilter(OriginContextFilter())
+    root_logger.addHandler(handler)
+
+    # set logging level
+    custodia_logger = getLogger('custodia')
     if debug:
         custodia_logger.setLevel(logging.DEBUG)
         custodia_logger.debug('Custodia debug logger enabled')
-        # If the global debug is enabled, turn debug on in all custodia.
+        # If the global debug is enabled, turn debug on in all 'custodia.*'
         # loggers
         logdict = logging.Logger.manager.loggerDict
         for name, obj in logdict.items():
@@ -46,6 +114,7 @@ def setup_logging(debug=False, auditfile='custodia.audit.log'):
     else:
         custodia_logger.setLevel(logging.INFO)
 
+    # setup file handler for audit log
     audit_logger = logging.getLogger('custodia.audit')
     if auditfile is not None and len(audit_logger.handlers) == 0:
         audit_fmt = logging.Formatter(LOGGING_FORMAT, LOGGING_DATEFORMAT)

--- a/custodia/message/common.py
+++ b/custodia/message/common.py
@@ -1,9 +1,9 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
 from __future__ import absolute_import
 
-import logging
+from custodia.log import getLogger
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 class InvalidMessage(Exception):

--- a/custodia/message/kem.py
+++ b/custodia/message/kem.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
 from __future__ import absolute_import
 
-import logging
 import os
 import time
 
@@ -13,10 +12,11 @@ from jwcrypto.jws import JWS
 from jwcrypto.jwt import JWT
 
 from custodia.httpd.authorizers import SimplePathAuthz
+from custodia.log import getLogger
 from custodia.message.common import InvalidMessage
 from custodia.message.common import MessageHandler
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 KEY_USAGE_SIG = 0
 KEY_USAGE_ENC = 1

--- a/custodia/server/__init__.py
+++ b/custodia/server/__init__.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 
 import argparse
 import importlib
-import logging
 import os
 import socket
 
@@ -17,7 +16,7 @@ from custodia.compat import url_escape
 from custodia.httpd.server import HTTPServer
 
 
-logger = logging.getLogger('custodia')
+logger = log.getLogger('custodia')
 CONFIG_SPECIALS = ['authenticators', 'authorizers', 'consumers', 'stores']
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,7 +47,7 @@ class TestsCommandLine(unittest.TestCase):
             pexec,
             '-Wignore',
             '-m', 'custodia.cli',
-            '--debug'
+            '--verbose'
         ]
         cli.extend(args)
 

--- a/tests/test_custodia.py
+++ b/tests/test_custodia.py
@@ -221,7 +221,7 @@ class CustodiaTests(unittest.TestCase):
             cls.pexec,
             '-Wignore',
             '-m', 'custodia.cli',
-            '--debug',
+            '--verbose',
             '--header', 'REMOTE_USER=test',
             '--server', cls.socket_url
         ]
@@ -427,7 +427,7 @@ class CustodiaHTTPSTests(CustodiaTests):
             cls.pexec,
             '-Wignore',
             '-m', 'custodia.cli',
-            '--debug',
+            '--verbose',
             '--cafile', cls.ca_cert,
             '--certfile', cls.client_cert,
             '--keyfile', cls.client_key,

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,7 +1,24 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
 from __future__ import absolute_import
 
+import logging.handlers
+
 import pkg_resources
+
+import pytest
+
+from custodia import log
+
+# pylint: disable=redefined-outer-name
+
+
+@pytest.fixture()
+def loghandler():
+    orig_handlers = logging.getLogger().handlers[:]
+    handler = logging.handlers.BufferingHandler(10240)
+    log.setup_logging(debug=False, auditfile=None, handler=handler)
+    yield handler
+    logging.getLogger().handlers = orig_handlers
 
 
 def test_import_about():
@@ -10,3 +27,32 @@ def test_import_about():
     assert __about__.__title__ == 'custodia'
     dist = pkg_resources.get_distribution('custodia')
     assert dist.version == __about__.__version__  # pylint: disable=no-member
+
+
+def test_logging_info(loghandler):
+    testlogger = log.getLogger('custodia.test')
+    assert testlogger.getEffectiveLevel() == logging.INFO
+    try:
+        raise ValueError('testmsg')
+    except ValueError:
+        testlogger.exception('some message')
+    assert len(loghandler.buffer) == 1
+    msg = loghandler.format(loghandler.buffer[0])
+    loghandler.flush()
+    assert msg.endswith('some message (ValueError: testmsg)')
+    assert "Traceback" not in msg
+
+
+def test_logging_debug(loghandler):
+    testlogger = log.getLogger('custodia.test')
+    testlogger.setLevel(logging.DEBUG)
+    try:
+        raise ValueError('testmsg with stack')
+    except ValueError:
+        testlogger.exception('some message')
+    assert len(loghandler.buffer) == 1
+    msg = loghandler.format(loghandler.buffer[0])
+    loghandler.flush()
+    assert "some message" in msg
+    assert "Traceback (most recent call last):\n" in msg
+    assert "ValueError: testmsg with stack" in msg


### PR DESCRIPTION
The custom logger factory getLogger() creates logger instances with a
special exception() method. The method logs exception stack trace only
in debug mode.

In standard mode (INFO), log.exception('message') prints
```
    message (ExceptionName: exception representation)
```

In debug mode (DEBUG), log.exception('message') prints
```
    message
    Traceback (most recent call last):
        ...
        stack trace
        ...
    ExceptionName: exception representation
```

This will allow us to log API exceptions with log.exception() or self.logger.exception(). Depending on the log level and debug flag, log.exception() either prints a short line or a full traceback for debugging.