### PR TITLE
Create CSStoreDenied Exception

### DIFF
--- a/custodia/plugin.py
+++ b/custodia/plugin.py
@@ -52,6 +52,10 @@ class CSStoreUnsupported(CustodiaException):
     pass
 
 
+class CSStoreDenied(CustodiaException):
+    pass
+
+
 class OptionHandler(object):
     """Handler and parser for plugin options
     """


### PR DESCRIPTION
The store API does not provide an API to
indicate that an operation is not allowed.

Create a new exception to be used on IPAVault
and IPACertReq to identify that an API
can be not allowed.

Besides, improve the log messages for this
cases.

Signed-off-by: Raildo Mascena <rmascena@redhat.com>