### PR TITLE
Plugin config: add special marker for inherit global

### DIFF
--- a/custodia/forwarder.py
+++ b/custodia/forwarder.py
@@ -4,12 +4,13 @@ from __future__ import absolute_import
 import uuid
 
 from custodia.client import CustodiaHTTPClient
-from custodia.plugin import HTTPConsumer, HTTPError, PluginOption, REQUIRED
+from custodia.plugin import HTTPConsumer, HTTPError
+from custodia.plugin import INHERIT_GLOBAL, PluginOption, REQUIRED
 
 
 class Forwarder(HTTPConsumer):
     forward_uri = PluginOption(str, REQUIRED, None)
-    tls_cafile = PluginOption(str, None, 'Path to CA file')
+    tls_cafile = PluginOption(str, INHERIT_GLOBAL(None), 'Path to CA file')
     tls_certfile = PluginOption(
         str, None, 'Path to cert file for client cert auth')
     tls_keyfile = PluginOption(


### PR DESCRIPTION
Sometimes it is desirable to inherit some values from [global] block,
e.g. 'debug' or 'tls_cafile'. Instead of a special case just for
'debug', I rather implemented a special value.

Example:

class ExamplePlugin(CustodiaPlugin)
    debug = PluginOption(bool, INHERIT_GLOBAL(False), '')

The value for 'debug' is first looked up in the config block for the
plugin. If the config block has no 'debug' stanza, then it is looked up
in [global]. In case global does have the setting either, it is set to
False.

Closes: #166
Signed-off-by: Christian Heimes <cheimes@redhat.com>