### PR TITLE
Backwards compatibility with older pytest

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -11,9 +11,16 @@ from custodia import log
 
 # pylint: disable=redefined-outer-name
 
+PYTEST_VERSION = tuple(int(p) for p in pytest.__version__.split('.'))
 
-@pytest.fixture()
-def loghandler():
+if PYTEST_VERSION < (2, 10):
+    yield_fixture = pytest.yield_fixture
+else:
+    yield_fixture = pytest.fixture
+
+
+@yield_fixture
+def loghandler(request):
     orig_handlers = logging.getLogger().handlers[:]
     handler = logging.handlers.BufferingHandler(10240)
     log.setup_logging(debug=False, auditfile=None, handler=handler)


### PR DESCRIPTION
pytest >= 2.10 supports yield based fixtures with pytest.fixture. In
pytest < 2.10 pytest.yield_fixture is required. But that function
also raises a deprecation warning in pytest >= 3.0.

https://docs.pytest.org/en/latest/fixture.html#fixture-finalization-executing-teardown-code

Signed-off-by: Christian Heimes <cheimes@redhat.com>