### PR TITLE
Add support for named instances and conf.d

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,6 @@ script:
 after_success:
   - python -m coverage combine
   - codecov
+
+after_failure:
+  - test -f tests/tmp/test_log.txt && cat tests/tmp/test_log.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,7 +12,8 @@ include man/custodia.7
 recursive-include contrib *.txt *.conf *.service *.socket Dockerfile
 
 recursive-include tests *.py
-recursive-include tests/ca *.conf *.key *.pem *.sh
+recursive-include tests *.conf
+recursive-include tests/ca *.key *.pem *.sh
 prune tests/tmp
 prune tests/ca/tmp
 

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -24,7 +24,9 @@ server_url [str]
        $ /usr/lib/systemd/systemd-activate -l $(pwd)/custodia.sock python -m custodia.server custodia.conf
 
 server_socket [str]
-   Path to :const:`AF_UNIX` socket file.
+   Path to :const:`AF_UNIX` socket file. In the absence of *server_url* and
+   *server_socket*, the default value for *server_socket* is
+   ``/var/run/custodia/${instance}.sock``.
 
 server_string [str]
    String to send as HTTP Server string
@@ -96,7 +98,52 @@ Special sections
 DEFAULT
 -------
 
-The :const:`DEFAULT` section contains default values for all sections.
+The :const:`DEFAULT` section contains default values for all sections. Some
+values are always defined. Predefined values can be overridden. Paths to
+files and directories are converted to absolute paths.
+
+hostname
+    hostname from ``socket.gethostname()``
+
+instance
+    name of the Custodia server instance or empty string
+
+configdir
+    Directory of the server's config file
+
+confdpattern
+    Glob pattern for additional config files
+
+libdir
+    Directory for persistent variable data (e.g. sqlite database)
+
+logdir
+    Directory for log files
+
+rundir
+    Directory for ephemeral data (e.g. ccache)
+
+socketdir
+    Directory for socket file
+
+Example for ``custodia --instance=example /etc/custodia/ex.conf`` with an
+empty config file::
+
+    [DEFAULT]
+    hostname = hostname.example
+    configdir = /etc/custodia
+    confdpattern = /etc/custodia/ex.conf.d/*.conf
+    libdir = /var/lib/custodia/example
+    logdir = /var/log/custodia/example
+    rundir = /var/run/custodia/example
+    socketdir = /var/run/custodia
+
+    [global]
+    auditlog = /var/log/custodia/example/custodia.audit.log
+    debug = False
+    server_socket = /var/run/custodia/example.sock
+    makedirs = True
+    umask = 027
 
 ENV
 ---

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -1,3 +1,4 @@
+
 api
 auditable
 auth
@@ -15,10 +16,13 @@ Barbican
 basename
 boolean
 cafile
+ccache
 certfile
 cli
 conf
+confdpattern
 config
+configdir
 custodia
 Custodia
 decrypt
@@ -26,6 +30,7 @@ del
 enctype
 filename
 gid
+hostname
 http
 Httpd
 Indices
@@ -34,6 +39,8 @@ jku
 json
 kem
 keyfile
+libdir
+logdir
 metadata
 mkdir
 namespace
@@ -43,8 +50,10 @@ plugin
 Plugin
 plugins
 rmdir
+rundir
 runtime
 sak
+socketdir
 sqlite
 stackable
 subcontainers

--- a/src/custodia/server/__init__.py
+++ b/src/custodia/server/__init__.py
@@ -1,41 +1,20 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
 from __future__ import absolute_import
 
-import argparse
 import importlib
 import os
-import socket
 
 import pkg_resources
 
 import six
 
 from custodia import log
-from custodia.compat import configparser
-from custodia.compat import url_escape
 from custodia.httpd.server import HTTPServer
+from .args import default_argparser
+from .config import parse_config as _parse_config
 
 
 logger = log.getLogger('custodia')
-CONFIG_SPECIALS = ['authenticators', 'authorizers', 'consumers', 'stores']
-
-
-default_argparser = argparse.ArgumentParser(
-    prog='custodia',
-    description='Custodia server'
-)
-default_argparser.add_argument(
-    '--debug',
-    action='store_true',
-    help='Debug mode'
-)
-default_argparser.add_argument(
-    'configfile',
-    nargs='?',
-    type=argparse.FileType('r'),
-    help='Path to custodia server config',
-    default='/etc/custodia/custodia.conf'
-)
 
 
 def attach_store(typename, plugins, stores):
@@ -97,63 +76,6 @@ def _create_plugin(parser, section, menu):
         hconf.update(parser.items(section))
         hconf.pop('handler')
         return handler(hconf)
-
-
-def _parse_config(args, config):
-    """Parse arguments and create basic configuration
-    """
-    defaults = {
-        # Do not use getfqdn(). Internaly it calls gethostbyaddr which might
-        # perform a DNS query.
-        'hostname': socket.gethostname(),
-    }
-
-    parser = configparser.ConfigParser(
-        interpolation=configparser.ExtendedInterpolation(),
-        defaults=defaults
-    )
-    parser.optionxform = str
-
-    with args.configfile as f:
-        parser.read_file(f)
-
-    for s in CONFIG_SPECIALS:
-        config[s] = dict()
-
-    # add env
-    parser['ENV'] = {
-        k: v.replace('$', '$$') for k, v in os.environ.items()
-        if not set(v).intersection('\r\n\x00')}
-
-    # parse globals first
-    if parser.has_section('global'):
-        for opt, val in parser.items('global'):
-            if opt in CONFIG_SPECIALS:
-                raise ValueError('"%s" is an invalid '
-                                 '[global] option' % opt)
-            config[opt] = val
-
-        config['tls_verify_client'] = parser.getboolean(
-            'global', 'tls_verify_client', fallback=False)
-        config['debug'] = parser.getboolean(
-            'global', 'debug', fallback=False)
-        if args.debug:
-            config['debug'] = True
-        config['auditlog'] = os.path.abspath(
-            config.get('auditlog', 'custodia.audit.log'))
-        config['umask'] = int(config.get('umask', '027'), 8)
-
-        url = config.get('server_url')
-        sock = config.get('server_socket')
-        if bool(url) == bool(sock):
-            raise ValueError("Exactly one of 'server_url' or "
-                             "'server_socket' is required.")
-        if sock:
-            server_socket = os.path.abspath(sock)
-            config['server_url'] = 'http+unix://{}/'.format(
-                url_escape(server_socket, ''))
-
-    return parser
 
 
 def _load_plugins(config, parser):

--- a/src/custodia/server/__init__.py
+++ b/src/custodia/server/__init__.py
@@ -11,10 +11,12 @@ import six
 from custodia import log
 from custodia.httpd.server import HTTPServer
 from .args import default_argparser
+from .args import parse_args as _parse_args
 from .config import parse_config as _parse_config
 
-
 logger = log.getLogger('custodia')
+
+__all__ = ['default_argparser', 'main']
 
 
 def attach_store(typename, plugins, stores):
@@ -122,15 +124,13 @@ def _load_plugins(config, parser):
 
 
 def main(argparser=None):
-    if argparser is None:
-        argparser = default_argparser
-    args = argparser.parse_args()
+    args = _parse_args(argparser=argparser)
     # parse arguments and populate config with basic settings
-    config = {}
-    cfgparser = _parse_config(args, config)
+    cfgparser, config = _parse_config(args)
     # initialize logging
     log.setup_logging(config['debug'], config['auditlog'])
-    logger.debug('Config file %s loaded', args.configfile)
+    logger.info('Custodia instance %s', args.instance or '<main>')
+    logger.debug('Config file(s) %s loaded', config['configfiles'])
     # load plugins after logging
     _load_plugins(config, cfgparser)
     # create and run server

--- a/src/custodia/server/args.py
+++ b/src/custodia/server/args.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2015-2017  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
+
+import argparse
+
+
+default_argparser = argparse.ArgumentParser(
+    prog='custodia',
+    description='Custodia server'
+)
+default_argparser.add_argument(
+    '--debug',
+    action='store_true',
+    help='Debug mode'
+)
+default_argparser.add_argument(
+    'configfile',
+    nargs='?',
+    type=argparse.FileType('r'),
+    help='Path to custodia server config',
+    default='/etc/custodia/custodia.conf'
+)

--- a/src/custodia/server/args.py
+++ b/src/custodia/server/args.py
@@ -2,6 +2,44 @@
 from __future__ import absolute_import
 
 import argparse
+import os
+
+
+class AbsFileType(argparse.FileType):
+    """argparse file type with absolute path
+    """
+    def __call__(self, string):
+        if string != '-':
+            string = os.path.abspath(string)
+        return super(AbsFileType, self).__call__(string)
+
+
+class ConfigfileAction(argparse.Action):
+    """Default action handler for configfile
+    """
+    default_path = '/etc/custodia/custodia.conf'
+    default_instance = '/etc/custodia/{instance}.conf'
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if values is None:
+            if namespace.instance is not None:
+                values = self.default_instance.format(
+                    instance=namespace.instance
+                )
+            else:
+                values = self.default_path
+            values = self.type(values)
+        setattr(namespace, self.dest, values)
+
+
+def instance_name(string):
+    """Check for valid instance name
+    """
+    invalid = ':/@'
+    if set(string).intersection(invalid):
+        msg = 'Invalid instance name {}'.format(string)
+        raise argparse.ArgumentTypeError(msg)
+    return string
 
 
 default_argparser = argparse.ArgumentParser(
@@ -14,9 +52,29 @@ default_argparser.add_argument(
     help='Debug mode'
 )
 default_argparser.add_argument(
+    '--instance',
+    type=instance_name,
+    help='Instance name',
+    default=None
+)
+default_argparser.add_argument(
     'configfile',
     nargs='?',
-    type=argparse.FileType('r'),
-    help='Path to custodia server config',
-    default='/etc/custodia/custodia.conf'
+    action=ConfigfileAction,
+    type=AbsFileType('r'),
+    help=('Path to custodia server config (default: '
+          '/etc/custodia/{instance}/custodia.conf)'),
 )
+
+
+def parse_args(args=None, argparser=None):
+    if argparser is None:
+        argparser = default_argparser
+
+    # namespace with default values
+    namespace = argparse.Namespace(
+        debug=False,
+        instance=None,
+    )
+
+    return argparser.parse_args(args, namespace)

--- a/src/custodia/server/config.py
+++ b/src/custodia/server/config.py
@@ -1,68 +1,166 @@
 # Copyright (C) 2015-2017  Custodia Project Contributors - see LICENSE file
 from __future__ import absolute_import
 
+import glob
 import os
 import socket
+
+import six
 
 from custodia.compat import configparser
 from custodia.compat import url_escape
 
 
-CONFIG_SPECIALS = ['authenticators', 'authorizers', 'consumers', 'stores']
+class CustodiaConfig(object):
+    CONFIG_SPECIALS = ['authenticators', 'authorizers', 'consumers', 'stores']
 
+    DEFAULT_PATHS = [
+        ('libdir', '/var/lib/custodia/{instance}'),
+        ('logdir', '/var/log/custodia/{instance}'),
+        ('rundir', '/var/run/custodia/{instance}'),
+        ('socketdir', '/var/run/custodia'),
+    ]
 
-def parse_config(args, config):
-    """Parse arguments and create basic configuration
-    """
-    defaults = {
-        # Do not use getfqdn(). Internaly it calls gethostbyaddr which might
-        # perform a DNS query.
-        'hostname': socket.gethostname(),
-    }
+    def __init__(self, args):
+        self.args = args
+        self.config = {}
+        self.defaults = None
+        self.parser = None
 
-    parser = configparser.ConfigParser(
-        interpolation=configparser.ExtendedInterpolation(),
-        defaults=defaults
-    )
-    parser.optionxform = str
+    def get_defaults(self):
+        configpath = self.args.configfile.name
+        instance = self.args.instance
+        defaults = {
+            # Do not use getfqdn(). Internaly it calls gethostbyaddr which
+            # might perform a DNS query.
+            'hostname': socket.gethostname(),
+            'configdir': os.path.dirname(configpath),
+            'confdpattern': os.path.join(configpath + '.d', '*.conf'),
+            'instance': instance if instance else '',
+        }
+        for name, path in self.DEFAULT_PATHS:
+            defaults[name] = os.path.abspath(path.format(**defaults))
+        return defaults
 
-    with args.configfile as f:
-        parser.read_file(f)
+    def create_parser(self):
+        parser = configparser.ConfigParser(
+            interpolation=configparser.ExtendedInterpolation(),
+            defaults=self.defaults
+        )
+        parser.optionxform = str
 
-    for s in CONFIG_SPECIALS:
-        config[s] = dict()
+        # add env
+        parser.add_section(u'ENV')
+        for k, v in os.environ.items():
+            if set(v).intersection('\r\n\x00'):
+                continue
+            if six.PY2:
+                k = k.decode('utf-8', 'replace')
+                v = v.decode('utf-8', 'replace')
+            parser.set(u'ENV', k, v.replace(u'$', u'$$'))
 
-    # add env
-    parser['ENV'] = {
-        k: v.replace('$', '$$') for k, v in os.environ.items()
-        if not set(v).intersection('\r\n\x00')}
+        # default globals
+        parser.add_section(u'global')
+        parser.set(u'global', u'auditlog', u'${logdir}/custodia.audit.log')
+        parser.set(u'global', u'debug', u'false')
+        parser.set(u'global', u'umask', u'027')
+        parser.set(u'global', u'makedirs', u'false')
 
-    # parse globals first
-    if parser.has_section('global'):
-        for opt, val in parser.items('global'):
-            if opt in CONFIG_SPECIALS:
+        return parser
+
+    def read_configs(self):
+        with self.args.configfile as f:
+            self.parser.read_file(f)
+
+        configfiles = [self.args.configfile.name]
+
+        pattern = self.parser.get(u'DEFAULT', u'confdpattern')
+        if pattern:
+            confdfiles = glob.glob(pattern)
+            confdfiles.sort()
+            for confdfile in confdfiles:
+                with open(confdfile) as f:
+                    self.parser.read_file(f)
+                configfiles.append(confdfile)
+
+        return configfiles
+
+    def makedirs(self):
+        for name, _ in self.DEFAULT_PATHS:
+            path = self.parser.get(u'DEFAULT', name)
+            parent = os.path.dirname(path)
+            # create parents according to umask
+            if not os.path.isdir(parent):
+                os.makedirs(parent)
+            # create final directory with restricted permissions
+            if not os.path.isdir(path):
+                os.mkdir(path, 0o700)
+
+    def populate_config(self):
+        config = self.config
+
+        for s in self.CONFIG_SPECIALS:
+            config[s] = {}
+
+        for opt, val in self.parser.items(u'global'):
+            if opt in self.CONFIG_SPECIALS:
                 raise ValueError('"%s" is an invalid '
                                  '[global] option' % opt)
             config[opt] = val
 
-        config['tls_verify_client'] = parser.getboolean(
+        config['tls_verify_client'] = self.parser.getboolean(
             'global', 'tls_verify_client', fallback=False)
-        config['debug'] = parser.getboolean(
+        config['debug'] = self.parser.getboolean(
             'global', 'debug', fallback=False)
-        if args.debug:
-            config['debug'] = True
-        config['auditlog'] = os.path.abspath(
-            config.get('auditlog', 'custodia.audit.log'))
+        config['makedirs'] = self.parser.getboolean(
+            'global', 'makedirs', fallback=False)
+        if self.args.debug:
+            config['debug'] = self.args.debug
+
+        config['auditlog'] = os.path.abspath(config.get('auditlog'))
         config['umask'] = int(config.get('umask', '027'), 8)
 
         url = config.get('server_url')
         sock = config.get('server_socket')
-        if bool(url) == bool(sock):
-            raise ValueError("Exactly one of 'server_url' or "
-                             "'server_socket' is required.")
+
+        if url and sock:
+            raise ValueError(
+                "'server_url' and 'server_socket' are mutually exclusive.")
+
+        if not url and not sock:
+            # no option but, use default socket path
+            socketdir = self.parser.get(u'DEFAULT', u'socketdir')
+            name = self.args.instance if self.args.instance else 'custodia'
+            sock = os.path.join(socketdir, name + '.sock')
+
         if sock:
             server_socket = os.path.abspath(sock)
             config['server_url'] = 'http+unix://{}/'.format(
                 url_escape(server_socket, ''))
 
-    return parser
+    def __call__(self):
+        self.defaults = self.get_defaults()
+        self.parser = self.create_parser()
+        self.config['configfiles'] = self.read_configs()
+        self.populate_config()
+        if self.config[u'makedirs']:
+            self.makedirs()
+        return self.parser, self.config
+
+
+def parse_config(args):
+    ccfg = CustodiaConfig(args)
+    return ccfg()
+
+
+def test(arglist):
+    from pprint import pprint
+    from .args import parse_args
+    args = parse_args(arglist)
+    parser, config = parse_config(args)
+    pprint(parser.items("DEFAULT"))
+    pprint(config)
+
+
+if __name__ == '__main__':
+    test(['--instance=demo', './tests/empty.conf'])

--- a/src/custodia/server/config.py
+++ b/src/custodia/server/config.py
@@ -1,0 +1,68 @@
+# Copyright (C) 2015-2017  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
+
+import os
+import socket
+
+from custodia.compat import configparser
+from custodia.compat import url_escape
+
+
+CONFIG_SPECIALS = ['authenticators', 'authorizers', 'consumers', 'stores']
+
+
+def parse_config(args, config):
+    """Parse arguments and create basic configuration
+    """
+    defaults = {
+        # Do not use getfqdn(). Internaly it calls gethostbyaddr which might
+        # perform a DNS query.
+        'hostname': socket.gethostname(),
+    }
+
+    parser = configparser.ConfigParser(
+        interpolation=configparser.ExtendedInterpolation(),
+        defaults=defaults
+    )
+    parser.optionxform = str
+
+    with args.configfile as f:
+        parser.read_file(f)
+
+    for s in CONFIG_SPECIALS:
+        config[s] = dict()
+
+    # add env
+    parser['ENV'] = {
+        k: v.replace('$', '$$') for k, v in os.environ.items()
+        if not set(v).intersection('\r\n\x00')}
+
+    # parse globals first
+    if parser.has_section('global'):
+        for opt, val in parser.items('global'):
+            if opt in CONFIG_SPECIALS:
+                raise ValueError('"%s" is an invalid '
+                                 '[global] option' % opt)
+            config[opt] = val
+
+        config['tls_verify_client'] = parser.getboolean(
+            'global', 'tls_verify_client', fallback=False)
+        config['debug'] = parser.getboolean(
+            'global', 'debug', fallback=False)
+        if args.debug:
+            config['debug'] = True
+        config['auditlog'] = os.path.abspath(
+            config.get('auditlog', 'custodia.audit.log'))
+        config['umask'] = int(config.get('umask', '027'), 8)
+
+        url = config.get('server_url')
+        sock = config.get('server_socket')
+        if bool(url) == bool(sock):
+            raise ValueError("Exactly one of 'server_url' or "
+                             "'server_socket' is required.")
+        if sock:
+            server_socket = os.path.abspath(sock)
+            config['server_url'] = 'http+unix://{}/'.format(
+                url_escape(server_socket, ''))
+
+    return parser

--- a/tests/empty.conf
+++ b/tests/empty.conf
@@ -1,0 +1,2 @@
+[globals]
+makedirs = false

--- a/tests/empty.conf.d/root.conf
+++ b/tests/empty.conf.d/root.conf
@@ -1,0 +1,2 @@
+[/]
+handler = Root

--- a/tests/test_custodia.py
+++ b/tests/test_custodia.py
@@ -42,6 +42,7 @@ server_version = "Secret/0.0.7"
 server_url = ${SOCKET_URL}
 auditlog = ${TEST_DIR}/test_audit.log
 debug = True
+makedirs = False
 tls_certfile = tests/ca/custodia-server.pem
 tls_keyfile = tests/ca/custodia-server.key
 tls_cafile = tests/ca/custodia-ca.pem

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,99 @@
+# Copyright (C) 2017  Custodia Project Contributors - see LICENSE file
+from __future__ import absolute_import
+
+import os
+import socket
+
+import pytest
+
+from custodia.server.args import parse_args
+from custodia.server.config import parse_config
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+EMPTY_CONF = os.path.join(HERE, 'empty.conf')
+
+
+@pytest.fixture()
+def args():
+    return parse_args([EMPTY_CONF])
+
+
+@pytest.fixture()
+def args_instance():
+    return parse_args(['--instance=testing', '--debug', EMPTY_CONF])
+
+
+def test_args(args):
+    assert not args.debug
+    assert args.instance is None
+    assert args.configfile.name == EMPTY_CONF
+
+
+def test_args_instance(args_instance):
+    assert args_instance.debug
+    assert args_instance.instance == 'testing'
+    assert args_instance.configfile.name == EMPTY_CONF
+
+
+def test_parse_config(args):
+    parser, config = parse_config(args)
+
+    assert parser.has_section(u'/')
+    assert parser.get(u'/', u'handler') == u'Root'
+
+    assert config == {
+        'auditlog': u'/var/log/custodia/custodia.audit.log',
+        'authenticators': {},
+        'authorizers': {},
+        'confdpattern': EMPTY_CONF + u'.d/*.conf',
+        'configdir': HERE,
+        'configfiles': [
+            EMPTY_CONF,
+            EMPTY_CONF + u'.d/root.conf'
+        ],
+        'consumers': {},
+        'debug': False,
+        'hostname': socket.gethostname(),
+        'instance': u'',
+        'libdir': u'/var/lib/custodia',
+        'logdir': u'/var/log/custodia',
+        'makedirs': False,
+        'rundir': u'/var/run/custodia',
+        'server_url': 'http+unix://%2Fvar%2Frun%2Fcustodia%2Fcustodia.sock/',
+        'socketdir': u'/var/run/custodia',
+        'stores': {},
+        'tls_verify_client': False,
+        'umask': 23
+    }
+
+
+def test_parse_config_instance(args_instance):
+    parser, config = parse_config(args_instance)
+
+    assert parser.has_section(u'/')
+    assert parser.get(u'/', u'handler') == u'Root'
+
+    assert config == {
+        'auditlog': u'/var/log/custodia/testing/custodia.audit.log',
+        'authenticators': {},
+        'authorizers': {},
+        'confdpattern': EMPTY_CONF + u'.d/*.conf',
+        'configdir': HERE,
+        'configfiles': [
+            EMPTY_CONF,
+            EMPTY_CONF + u'.d/root.conf'
+        ],
+        'consumers': {},
+        'debug': True,
+        'hostname': socket.gethostname(),
+        'instance': u'testing',
+        'libdir': u'/var/lib/custodia/testing',
+        'logdir': u'/var/log/custodia/testing',
+        'makedirs': False,
+        'rundir': u'/var/run/custodia/testing',
+        'server_url': 'http+unix://%2Fvar%2Frun%2Fcustodia%2Ftesting.sock/',
+        'socketdir': u'/var/run/custodia',
+        'stores': {},
+        'tls_verify_client': False,
+        'umask': 23
+    }


### PR DESCRIPTION
Custodia server and client now support multiple named instances. The
server also has a bunch of variables defined by default and can load
config sniplets from a conf.d directory. For custodia-cli the instance
name can either be specified with the env var CUSTODIA_INSTANCE or
with ``custodia-cli --instance=NAME``.

Signed-off-by: Christian Heimes <cheimes@redhat.com>