### PR TITLE
Introduce bin/ file for in-tree scripts

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include setup.py setup.cfg
 include Makefile LICENSE README
 include *.md *.ini .coveragerc
+include bin/custodia bin/custodia-cli
 
 include custodia.conf
 recursive-include examples *.key *.db

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ release: clean
 	@echo "  twine-3 upload dist/*.gz dist/*.whl"
 
 run: egg_info
-	PYTHONPATH=$(CURDIR)/src $(PYTHON) -m custodia.server $(CONF)
+	$(PYTHON) $(CURDIR)/bin/custodia $(CONF)
 
 
 .PHONY: rpmroot rpmfiles rpm

--- a/bin/custodia
+++ b/bin/custodia
@@ -1,0 +1,25 @@
+#!/usr/bin/python2.7
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SRC = os.path.join(os.path.dirname(HERE), 'src')
+
+sys.path.insert(0, SRC)
+
+
+def main(dist='custodia', group='console_scripts', name='custodia'):
+    # delay pkg_resources after sys.path changes
+    import pkg_resources
+    pkg_resources.working_set.add_entry(SRC)
+    ep = pkg_resources.get_entry_info(dist, group, name)
+    if os.path.normpath(ep.dist.location) != os.path.normpath(SRC):
+        raise RuntimeError(ep.dist.location)
+    if hasattr(ep, 'resolve'):
+        func = ep.resolve()
+    else:
+        func = ep.load(require=False)
+    sys.exit(func())
+
+if __name__ == '__main__':
+    main()

--- a/bin/custodia-cli
+++ b/bin/custodia-cli
@@ -1,0 +1,25 @@
+#!/usr/bin/python2.7
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SRC = os.path.join(os.path.dirname(HERE), 'src')
+
+sys.path.insert(0, SRC)
+
+
+def main(dist='custodia', group='console_scripts', name='custodia-cli'):
+    # delay pkg_resources after sys.path changes
+    import pkg_resources
+    pkg_resources.working_set.add_entry(SRC)
+    ep = pkg_resources.get_entry_info(dist, group, name)
+    if os.path.normpath(ep.dist.location) != os.path.normpath(SRC):
+        raise RuntimeError(ep.dist.location)
+    if hasattr(ep, 'resolve'):
+        func = ep.resolve()
+    else:
+        func = ep.load(require=False)
+    sys.exit(func())
+
+if __name__ == '__main__':
+    main()

--- a/custodia.conf
+++ b/custodia.conf
@@ -14,6 +14,7 @@ server_version = "Secret/0.0.7"
 debug = True
 #server_url = https://0.0.0.0:10443
 server_socket = ./server_socket
+auditlog = ${configdir}/custodia.audit.log
 tls_certfile = tests/ca/custodia-server.pem
 tls_keyfile = tests/ca/custodia-server.key
 tls_cafile = tests/ca/custodia-ca.pem


### PR DESCRIPTION
pkg_resources, namespace packages and PYTHONPATH don't mix and mangle very
well. Under some yet-unknown conditions, pkg_resource and 'python -m'
prefer global installation of custodia over in-tree version. It's
probably related to nspkg.pth files.

The new scripts bin/custodia and bin/custodia-cli ensure that the
entry points and Python sources from ./src/custodia are used.

Signed-off-by: Christian Heimes <cheimes@redhat.com>