### PR TITLE
Revert to /path/logdir/audit.log

### DIFF
--- a/contrib/config/custodia/custodia.conf
+++ b/contrib/config/custodia/custodia.conf
@@ -1,7 +1,6 @@
 # /etc/custodia/custodia.conf
 [global]
 debug = true
-auditlog = ${logdir}/audit.log
 
 [store:sqlite]
 handler = SqliteStore

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -139,7 +139,7 @@ empty config file::
     socketdir = /var/run/custodia
 
     [global]
-    auditlog = /var/log/custodia/example/custodia.audit.log
+    auditlog = /var/log/custodia/example/audit.log
     debug = False
     server_socket = /var/run/custodia/example.sock
     makedirs = True

--- a/src/custodia/server/config.py
+++ b/src/custodia/server/config.py
@@ -61,7 +61,7 @@ class CustodiaConfig(object):
 
         # default globals
         parser.add_section(u'global')
-        parser.set(u'global', u'auditlog', u'${logdir}/custodia.audit.log')
+        parser.set(u'global', u'auditlog', u'${logdir}/audit.log')
         parser.set(u'global', u'debug', u'false')
         parser.set(u'global', u'umask', u'027')
         parser.set(u'global', u'makedirs', u'false')

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -42,7 +42,7 @@ def test_parse_config(args):
     assert parser.get(u'/', u'handler') == u'Root'
 
     assert config == {
-        'auditlog': u'/var/log/custodia/custodia.audit.log',
+        'auditlog': u'/var/log/custodia/audit.log',
         'authenticators': {},
         'authorizers': {},
         'confdpattern': EMPTY_CONF + u'.d/*.conf',
@@ -74,7 +74,7 @@ def test_parse_config_instance(args_instance):
     assert parser.get(u'/', u'handler') == u'Root'
 
     assert config == {
-        'auditlog': u'/var/log/custodia/testing/custodia.audit.log',
+        'auditlog': u'/var/log/custodia/testing/audit.log',
         'authenticators': {},
         'authorizers': {},
         'confdpattern': EMPTY_CONF + u'.d/*.conf',


### PR DESCRIPTION
custodia.audit.log is only used for local test servers. The designated
name for the audit log file is simply audit.log. Let's keep it the
default setting.

Signed-off-by: Christian Heimes <cheimes@redhat.com>