### PR TITLE
Upgrade pip first

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,10 @@ matrix:
       env: TOXENV=pep8py3
 
 install:
-  - pip install --upgrade pip setuptools codecov
+  - pip install --upgrade pip
+  - pip install --upgrade setuptools
   - pip --version
-  - pip install tox
+  - pip install --upgrade codecov tox
   - tox --version
 
 script:


### PR DESCRIPTION
"pip install --upgrade pip setuptools codecov" breaks. Upgrade pip
first, then install/upgrade remaining packages with most recent pip.

https://github.com/kennethreitz/requests/issues/4006

Signed-off-by: Christian Heimes <cheimes@redhat.com>