### PR TITLE
Prepare release and add make releasecheck

### DIFF
--- a/README
+++ b/README
@@ -7,6 +7,8 @@ Custodia
 
 A tool for managing secrets.
 
+See our `Quick Start Guide <docs/source/quick.rst>`__
+
 Custodia is a project that aims to define an API for modern cloud
 applications that allows to easily store and share passwords, tokens,
 certificates and any other secret in a way that keeps data secure,

--- a/custodia.spec
+++ b/custodia.spec
@@ -3,7 +3,7 @@
 %global with_etcdstore 1
 %endif
 
-%{!?version: %define version 0.3.1}
+%{!?version: %define version 0.5.dev1}
 
 Name:           custodia
 Version:        %{version}

--- a/docs/source/readme.rst
+++ b/docs/source/readme.rst
@@ -6,6 +6,8 @@ Custodia
 
 A tool for managing secrets.
 
+See our `Quick Start Guide <docs/source/quick.rst>`__
+
 Custodia is a project that aims to define an API for modern cloud
 applications that allows to easily store and share passwords, tokens,
 certificates and any other secret in a way that keeps data secure,
@@ -50,3 +52,4 @@ Some APIs are provisional and may change in the future.
 
 -  Command line interface in module ``custodia.cli``.
 -  The script custodia-cli.
+


### PR DESCRIPTION
make releasecheck performs a couple of actions that ensure we are in a
good state for a new release.

Signed-off-by: Christian Heimes <cheimes@redhat.com>