### PR TITLE
doc: update quickstart guide to create log dir

### DIFF
--- a/docs/source/quick.rst
+++ b/docs/source/quick.rst
@@ -27,6 +27,7 @@ the comments)::
    [global]
    # Listen on a socket named './quick'
    server_socket = ./quick
+   logdir = log
 
    # Accepts any request that specifies an arbitrary REMOTE_USER header
    [auth:header]
@@ -48,6 +49,11 @@ the comments)::
    [/]
    handler = Root
    store = quick
+
+Also create the ``logdir`` directory (where Custodia writes its
+audit log)::
+
+   $ mkdir -p log
 
 
 Running


### PR DESCRIPTION
With the current quickstart guide, starting the server fails because
the /var/log/custodia directory does not exist (or is not writable
by regular user).  Update the example quick.conf to specify 'log' as
the logdir, and instruct the reader to create it.