### PR TITLE
Move quick guide configs to separate files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ custodia.audit.log
 secrets.db
 server_socket
 vol
+
+/docs/source/quick/quick.audit.log
+/docs/source/quick/quick.db
+/docs/source/quick/quick.key
+/docs/source/quick/quick

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,7 @@ include bin/custodia bin/custodia-cli
 include custodia.conf
 recursive-include examples *.key *.db
 
-recursive-include docs *.py *.rst
+recursive-include docs *.conf *.py *.rst
 include docs/Makefile
 include man/custodia.7
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ PYTHON := python3
 TOX := $(PYTHON) -m tox --sitepackages
 DOCS_DIR = docs
 SERVER_SOCKET = $(CURDIR)/server_socket
+QUICK_GUIDE = docs/source/quick
+QUICK_SOCKET = $(QUICK_GUIDE)/quick
 
 RPMBUILD = $(CURDIR)/dist/rpmbuild
 
@@ -35,7 +37,7 @@ all: clean_socket lint pep8 test docs
 	echo "All tests passed"
 
 clean_socket:
-	rm -f $(SERVER_SOCKET) $(CONTAINER_SOCKET)
+	rm -f $(SERVER_SOCKET) $(CONTAINER_SOCKET) $(QUICK_SOCKET)
 
 clean_coverage:
 	rm -f .coverage .coverage.*
@@ -55,6 +57,9 @@ clean: clean_socket clean_coverage
 	find ./ -depth -name __pycache__ -exec rm -rf {} \;
 	rm -rf tests/tmp
 	rm -rf vol
+	rm -f $(QUICK_GUIDE)/quick.audit.log \
+	    $(QUICK_GUIDE)/quick.db \
+	    $(QUICK_GUIDE)/quick.key
 
 cscope:
 	git ls-files | xargs pycscope
@@ -82,7 +87,7 @@ docs: $(DOCS_DIR)/source/readme.rst
 	PYTHONPATH=$(CURDIR)/src \
 	    $(MAKE) -C $(DOCS_DIR) html SPHINXBUILD="$(PYTHON) -m sphinx"
 
-.PHONY: install egg_info run packages release releasecheck
+.PHONY: install egg_info run quickrun packages release releasecheck
 install: clean_socket egg_info
 	$(PYTHON) setup.py install --root "$(PREFIX)"
 	install -d "$(PREFIX)/share/man/man7"
@@ -123,6 +128,10 @@ releasecheck: clean
 run: egg_info
 	$(PYTHON) $(CURDIR)/bin/custodia $(CONF)
 
+quickrun: egg_info
+	@ # sed -n -e 's/.*\$$ \(alias\|curl\)/\1/p' docs/source/quick.rst
+	@ # sed 's,./quick,$(QUICK_SOCKET),g'
+	$(PYTHON) bin/custodia $(QUICK_GUIDE)/quick.conf
 
 .PHONY: rpmroot rpmfiles rpm
 rpmroot:

--- a/docs/source/quick/quick.conf
+++ b/docs/source/quick/quick.conf
@@ -1,0 +1,33 @@
+[DEFAULT]
+# Custodia defines these values to /var/run/custodia by default.
+logdir = ${configdir}
+libdir = ${configdir}
+rundir = ${configdir}
+socketdir = ${configdir}
+
+[global]
+# Listen on a socket file 'quick' in the same directory as the config file
+server_socket = ${socketdir}/quick
+auditlog = ${logdir}/quick.audit.log
+debug = true
+
+# Accepts any request that specifies an arbitrary REMOTE_USER header
+[auth:header]
+handler = SimpleHeaderAuth
+header = REMOTE_USER
+
+# Allow requests for all paths under '/' and '/secrets/'
+[authz:paths]
+handler = SimplePathAuthz
+paths = / /secrets/
+
+# Store secrets in a sqlite database called quick.db in the table 'secrets'
+[store:quick]
+handler = SqliteStore
+dburi = ${libdir}/quick.db
+table = secrets
+
+# Serve starting from '/' and using the 'quick' store and the 'Root' handler
+[/]
+handler = Root
+store = quick

--- a/docs/source/quick/quick.conf.d/00-sak.conf
+++ b/docs/source/quick/quick.conf.d/00-sak.conf
@@ -1,0 +1,4 @@
+[auth:sak]
+handler = SimpleAuthKeys
+store_namespace = keys/sak
+store = quick

--- a/docs/source/quick/quick.conf.d/10-namespace.conf
+++ b/docs/source/quick/quick.conf.d/10-namespace.conf
@@ -1,0 +1,4 @@
+[authz:namespaces]
+handler = UserNameSpace
+path = /secrets/
+store = quick

--- a/docs/source/quick/quick.conf.d/20-encrypted.conf
+++ b/docs/source/quick/quick.conf.d/20-encrypted.conf
@@ -1,0 +1,20 @@
+[store:overlayed]
+handler = SqliteStore
+dburi = ${libdir}/quick.db
+table = encrypted
+
+[store:encrypted]
+handler = EncryptedOverlay
+backing_store = overlayed
+master_key = ${libdir}/quick.key
+autogen_master_key = true
+master_enctype = A128CBC-HS256
+
+[authz:encrypted]
+handler = UserNameSpace
+path = /encrypted/
+store = encrypted
+
+[/encrypted]
+handler = Secrets
+store = encrypted


### PR DESCRIPTION
The configuration from the quick start guide is currently hard to test.
Move all config sniplets into separate files and include them with
`literalinclude`.

Use the new conf.d feature to include additional config files.

Make all files relative to ${configdir}

Use autogen_master_key to create the master key for encrypted overlay.

Replaces PR #196.

Signed-off-by: Christian Heimes <cheimes@redhat.com>