### PR TITLE
WIP: Add secret_protection option to encgen driver

### DIFF
--- a/tests/test_custodia.py
+++ b/tests/test_custodia.py
@@ -174,6 +174,8 @@ class CustodiaTests(unittest.TestCase):
     verify_client = 'False'
     test_dir = 'tests/tmp'
 
+    maxDiff = None
+
     @classmethod
     def setUpClass(cls):
         env = os.environ.copy()


### PR DESCRIPTION
This option adds the key name into the protected header of the JWE token
used to encrypt secrets. This allows Custodia to verify that the database
was not tampered with (e.g. secrets swapped between keys).

WIP because we do no have tests coveing this yet.

Also comments very welcome.