### PR TITLE
Adding support to SSLError for HTTPServer

### DIFF
--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -71,6 +71,7 @@ stackable
 subcontainers
 subtree
 systemd
+ve
 timestamp
 tls
 TLS


### PR DESCRIPTION
We should handle SSLError for an TLS Server
on Custodia and log the error details.

Signed-off-by: Raildo Mascena <rmascena@redhat.com>
Closes: #200