### PR TITLE
    Make key container creation idempotent

### DIFF
--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -28,6 +28,7 @@ custodia
 Custodia
 decrypt
 del
+doesn
 enctype
 filename
 gid
@@ -68,3 +69,4 @@ tox
 uid
 unix
 url
+ve

--- a/src/custodia/client.py
+++ b/src/custodia/client.py
@@ -12,6 +12,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from requests.compat import unquote, urlparse
 
+# pylint: disable=import-error
 from requests.packages.urllib3.connection import HTTPConnection
 from requests.packages.urllib3.connectionpool import HTTPConnectionPool
 

--- a/src/custodia/secrets.py
+++ b/src/custodia/secrets.py
@@ -206,8 +206,9 @@ class Secrets(HTTPConsumer):
                 "Create: Permission to perform this operation was denied")
             raise HTTPError(403)
         except CSStoreExists:
-            self.logger.exception('Create: Key already exists')
-            raise HTTPError(409)
+            self.logger.debug('Create: Key already exists')
+            response['code'] = 200
+            return
         except CSStoreError:
             self.logger.exception('Create: Internal server error')
             raise HTTPError(500)

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -273,14 +273,15 @@ class SecretsTests(unittest.TestCase):
             self.POST(req, rep)
         self.assertEqual(err.exception.code, 405)
 
-    def test_8_CREATEcont_erros_409(self):
+    def test_8_CREATEcont_already_exists(self):
         req = {'remote_user': 'test',
                'trail': ['test', 'exists', '']}
         rep = {}
         self.POST(req, rep)
-        with self.assertRaises(HTTPError) as err:
-            self.POST(req, rep)
-        self.assertEqual(err.exception.code, 409)
+        self.assertEqual(rep['code'], 201)
+        # Try to create the container again
+        self.POST(req, rep)
+        self.assertEqual(rep['code'], 200)
 
     def test_8_DESTROYcont(self):
         req = {'remote_user': 'test',


### PR DESCRIPTION
   
    Container creation returns a 409 Conflict if the container
    already exists, but since the request doesn't take any
    additional parameters, there's really no conflict.
    Update the API return, if the container exists, to 200 OK.
    Users could still distinguish whether the container
    already existed by checking for 200 OK vs 201 Created.
    
    Signed-off-by: Raildo Mascena <rmascena@redhat.com>
    Closes: #206
