### PR TITLE
Add connection timeout to Custodia client

### DIFF
--- a/src/custodia/cli/__init__.py
+++ b/src/custodia/cli/__init__.py
@@ -70,6 +70,19 @@ def split_header(arg):
     return name, value
 
 
+def timeout(arg):
+    try:
+        arg = float(arg)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError('Argument is not a float')
+    if arg < 0.0:
+        raise argparse.ArgumentTypeError('Argument is negative')
+    if arg == 0.0:
+        # no timeout
+        return None
+    return arg
+
+
 group = main_parser.add_mutually_exclusive_group()
 group.add_argument(
     '--server',
@@ -99,6 +112,11 @@ main_parser.add_argument(
 )
 main_parser.add_argument(
     '--debug', action='store_true',
+)
+
+main_parser.add_argument(
+    '--timeout', type=timeout, default=10.,
+    help='Connection timeout'
 )
 
 # TLS
@@ -300,6 +318,7 @@ def parse_args(arglist=None):
     if args.certfile:
         args.client_conn.set_client_cert(args.certfile, args.keyfile)
         args.client_conn.headers['CUSTODIA_CERT_AUTH'] = 'true'
+    args.client_conn.timeout = args.timeout
 
     return args
 

--- a/src/custodia/client.py
+++ b/src/custodia/client.py
@@ -60,6 +60,7 @@ DEFAULT_HEADERS = {'Content-Type': 'application/json'}
 
 
 class CustodiaHTTPClient(object):
+    timeout = None  # seconds (float)
 
     def __init__(self, url):
         self.session = requests.Session()
@@ -96,6 +97,7 @@ class CustodiaHTTPClient(object):
     def _request(self, cmd, path, **kwargs):
         self._last_response = None
         url = self._join_url(path)
+        kwargs.setdefault('timeout', self.timeout)
         kwargs['headers'] = self._add_headers(**kwargs)
         logger.debug("%s %s", cmd.__name__.upper(), url)
         self._last_response = cmd(url, **kwargs)

--- a/src/custodia/forwarder.py
+++ b/src/custodia/forwarder.py
@@ -17,6 +17,7 @@ class Forwarder(HTTPConsumer):
         str, None, 'Path to key file for client cert auth')
     forward_headers = PluginOption('json', '{}', None)
     prefix_remote_user = PluginOption(bool, True, None)
+    timeout = PluginOption(float, 10.0, 'Connection timeout in seconds')
 
     def __init__(self, config, section):
         super(Forwarder, self).__init__(config, section)
@@ -25,6 +26,7 @@ class Forwarder(HTTPConsumer):
             self.client.set_client_cert(self.tls_certfile, self.tls_keyfile)
         if self.tls_cafile is not None:
             self.client.set_ca_cert(self.tls_cafile)
+        self.client.timeout = self.timeout
         self.uuid = str(uuid.uuid4())
         # pylint: disable=unsubscriptable-object
         # pylint: disable=unsupported-assignment-operation

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2015  Custodia Project Contributors - see LICENSE file
 from __future__ import absolute_import
 
+import argparse
 import os
 import shlex
 import socket
@@ -8,7 +9,11 @@ import subprocess
 import sys
 import unittest
 
+import pytest
+
 import six
+
+from custodia.cli import timeout
 
 
 def find_free_address():
@@ -95,3 +100,12 @@ class TestsCommandLine(unittest.TestCase):
         self.assertIn(u'[custodia.clients]', output)
         self.assertIn(u'[custodia.consumers]', output)
         self.assertIn(u'[custodia.stores]', output)
+
+
+def test_timeout():
+    assert timeout('1') == 1
+    assert timeout('1.5') == 1.5
+    assert timeout('0') is None
+    assert timeout('0.0') is None
+    pytest.raises(argparse.ArgumentTypeError, timeout, '-1')
+    pytest.raises(argparse.ArgumentTypeError, timeout, 'invalid')

--- a/tests/test_custodia.py
+++ b/tests/test_custodia.py
@@ -242,6 +242,8 @@ class CustodiaTests(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        if cls.custodia_process.poll() is not None:
+            raise AssertionError("Custodia server crashed, see test_log.txt")
         cls.custodia_process.terminate()
         cls.custodia_process.wait()
 


### PR DESCRIPTION
Custodia client classes have grown a default timeout instance attribute.
The forwarder plugin and CLI have a new timeout option. The default
timeout for both is 10 seconds.

Signed-off-by: Christian Heimes <cheimes@redhat.com>
Closes: #208