### PR TITLE
Add secret_protection option to encgen driver

### DIFF
--- a/tests/test_custodia.py
+++ b/tests/test_custodia.py
@@ -118,6 +118,7 @@ handler = custodia.store.encgen.EncryptedOverlay
 backing_store = simple
 master_key = ${TEST_DIR}/test_mkey.conf
 master_enctype = A128CBC-HS256
+secret_protection = encrypt
 
 [authz:enc]
 handler = SimplePathAuthz

--- a/tests/test_custodia.py
+++ b/tests/test_custodia.py
@@ -177,6 +177,8 @@ class CustodiaTests(unittest.TestCase):
     verify_client = 'False'
     test_dir = 'tests/tmp'
 
+    maxDiff = None
+
     @classmethod
     def setUpClass(cls):
         env = os.environ.copy()


### PR DESCRIPTION
This option adds the key name into the protected header of the JWE token
used to encryp secrets. This allows Custodia to verify that the database
was not tampered with (e.g. secrets swapped between keys).

If enabled this option will cause exception when pre-existing keys
generated without the protected header are looked up.
however turning off this option will not cause failures.

Signed-off-by: Simo Sorce <simo@redhat.com>
Signed-off-by:  Raildo Mascena <rmascena@redhat.com>