### PR TITLE
Fix of container documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -196,13 +196,13 @@ POST /secrets/mycontainer/
 Default containers may be automatically created by an implementation.
 
 Returns:
+- 200 if the container already exists
 - 201 in case of success.
 - 400 if the request format is invalid
 - 401 if authentication is necessary
 - 403 if access to the key is forbidden
 - 404 one of the elements of the path is not a valid container
 - 406 not acceptable, type unknown/not permitted
-- 409 if the container already exists
 - 501 if the API is not supported
 
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -175,13 +175,13 @@ Default containers may be automatically created by an implementation.
 
 Returns:
 
+- 200 if the container already exists
 - 201 in case of success
 - 400 if the request format is invalid
 - 401 if authentication is necessary
 - 403 if access to the key is forbidden
 - 404 one of the elements of the path is not a valid container
 - 406 not acceptable, type unknown/not permitted
-- 409 if the container already exists
 
 Deleting containers
 -------------------


### PR DESCRIPTION
In #206 was changed of return code for case when user requests
creation of existing container. It was changed from 409 to 200.
This patch propagates this change to the documentation.

Resolves #216

Signed-off-by: Petr Čech <pcech@redhat.com>