### PR TITLE
Fix custodia tests.

### DIFF
--- a/tests/test_custodia.py
+++ b/tests/test_custodia.py
@@ -217,7 +217,22 @@ class CustodiaTests(unittest.TestCase):
                 cls.pexec + ['-m', 'custodia.server', custodia_conf],
                 env=env, stdout=logfile, stderr=logfile
             )
-        time.sleep(1)
+        # check whether custodia server ready for processing or not
+        retry_number = 0
+        max_retries = 10
+        for i in range(max_retries):
+            with open(test_log_file, 'r') as logfile:
+                lines = [line for line in logfile if ' server ' in line]
+                if not lines:
+                    time.sleep(0.5)
+                    retry_number = i + 1
+                else:
+                    break
+
+        if retry_number == max_retries:
+            raise AssertionError(
+                "Perphaps custodia server was not started correctly")
+
         if p.poll() is not None:
             raise AssertionError(
                 "Premature termination of Custodia server, see test_log.txt")


### PR DESCRIPTION
I faced a next problem:
```
[builder@localhost python3]$ python3 -m coverage run -m pytest -v 
===================================== test session starts =====================================
platform linux -- Python 3.5.4, pytest-3.2.1, py-1.4.34, pluggy-0.4.0 -- /usr/bin/python3
cachedir: .cache
rootdir: /usr/src/RPM/BUILD/python3, inifile: tox.ini
plugins: cov-2.4.0
collected 110 items                                                                            

tests/test_authenticators.py::TestAuthenticators::test_cred PASSED
tests/test_authenticators.py::TestAuthenticators::test_header PASSED
tests/test_cli.py::TestsCommandLine::test_connection_error_with_server_option PASSED
tests/test_cli.py::TestsCommandLine::test_connection_error_with_uds_urlpath_option PASSED
tests/test_cli.py::TestsCommandLine::test_help PASSED
tests/test_cli.py::TestsCommandLine::test_plugins PASSED
tests/test_custodia.py::CustodiaTests::test_0_0_setup FAILED
tests/test_custodia.py::CustodiaTests::test_0_create_container PASSED
tests/test_custodia.py::CustodiaTests::test_0_delete_container PASSED
tests/test_custodia.py::CustodiaTests::test_0_get_root PASSED
tests/test_custodia.py::CustodiaTests::test_1_set_simple_key PASSED
tests/test_custodia.py::CustodiaTests::test_1_set_simple_key_cli PASSED
tests/test_custodia.py::CustodiaTests::test_2_get_simple_key PASSED
tests/test_custodia.py::CustodiaTests::test_2_get_simple_key_cli PASSED
tests/test_custodia.py::CustodiaTests::test_3_list_container PASSED
tests/test_custodia.py::CustodiaTests::test_3_list_container_cli PASSED
tests/test_custodia.py::CustodiaTests::test_4_del_simple_key PASSED
tests/test_custodia.py::CustodiaTests::test_4_del_simple_key_cli PASSED
tests/test_custodia.py::CustodiaTests::test_5_list_empty PASSED
tests/test_custodia.py::CustodiaTests::test_6_create_forwarded_container FAILED
tests/test_custodia.py::CustodiaTests::test_7_delete_forwarded_container FAILED

tests/test_custodia.py::CustodiaTests::test_9_loop PASSED
tests/test_custodia.py::CustodiaTests::test_A_enc_1_create_container PASSED
tests/test_custodia.py::CustodiaTests::test_A_enc_2_set_simple_key PASSED
tests/test_custodia.py::CustodiaTests::test_B_1_kem_create_container PASSED
tests/test_custodia.py::CustodiaTests::test_B_1_kem_space PASSED
tests/test_custodia.py::CustodiaHTTPSTests::test_0_0_setup FAILED
tests/test_custodia.py::CustodiaHTTPSTests::test_0_create_container PASSED
tests/test_custodia.py::CustodiaHTTPSTests::test_0_delete_container PASSED
tests/test_custodia.py::CustodiaHTTPSTests::test_0_get_root PASSED
tests/test_custodia.py::CustodiaHTTPSTests::test_1_set_simple_key PASSED
tests/test_custodia.py::CustodiaHTTPSTests::test_1_set_simple_key_cli PASSED
tests/test_custodia.py::CustodiaHTTPSTests::test_2_get_simple_key PASSED
tests/test_custodia.py::CustodiaHTTPSTests::test_2_get_simple_key_cli PASSED
tests/test_custodia.py::CustodiaHTTPSTests::test_3_list_container PASSED
tests/test_custodia.py::CustodiaHTTPSTests::test_3_list_container_cli PASSED
tests/test_custodia.py::CustodiaHTTPSTests::test_4_del_simple_key PASSED
tests/test_custodia.py::CustodiaHTTPSTests::test_4_del_simple_key_cli PASSED
tests/test_custodia.py::CustodiaHTTPSTests::test_5_list_empty PASSED
tests/test_custodia.py::CustodiaHTTPSTests::test_6_create_forwarded_container FAILED
tests/test_custodia.py::CustodiaHTTPSTests::test_7_delete_forwarded_container FAILED
tests/test_custodia.py::CustodiaHTTPSTests::test_9_loop PASSED
tests/test_custodia.py::CustodiaHTTPSTests::test_A_enc_1_create_container PASSED
tests/test_custodia.py::CustodiaHTTPSTests::test_A_enc_2_set_simple_key PASSED
tests/test_custodia.py::CustodiaHTTPSTests::test_B_1_kem_create_container PASSED
tests/test_custodia.py::CustodiaHTTPSTests::test_B_1_kem_space PASSED
tests/test_custodia.py::CustodiaHTTPSTests::test_C_client_cert_auth FAILED
tests/test_custodia.py::CustodiaHTTPSTests::test_client_no_ca_trust PASSED
tests/test_custodia.py::CustodiaHTTPSTests::test_client_no_client_cert PASSED
tests/test_message_kem.py::KEMTests::test_1_Parse_GET PASSED
tests/test_message_kem.py::KEMTests::test_2_KEMClient PASSED
tests/test_message_kem.py::KEMTests::test_3_KEMClient PASSED
tests/test_message_kem.py::KEMTests::test_4_KEMClient_SET PASSED
tests/test_misc.py::test_import_about PASSED
tests/test_misc.py::test_logging_info PASSED
tests/test_misc.py::test_logging_debug PASSED
tests/test_plugins.py::TestCustodiaPlugins::test_authenticators PASSED
tests/test_plugins.py::TestCustodiaPlugins::test_authorizers PASSED
tests/test_plugins.py::TestCustodiaPlugins::test_clients PASSED
tests/test_plugins.py::TestCustodiaPlugins::test_stores PASSED
tests/test_secrets.py::SecretsTests::test_0_LISTkey_404 PASSED
tests/test_secrets.py::SecretsTests::test_10_LIST_subcontainer_and_keys PASSED
tests/test_secrets.py::SecretsTests::test_11_GET_container PASSED
tests/test_secrets.py::SecretsTests::test_1_PUTKey PASSED
tests/test_secrets.py::SecretsTests::test_2_GETKey PASSED
tests/test_secrets.py::SecretsTests::test_3_LISTKeys PASSED
tests/test_secrets.py::SecretsTests::test_4_PUTKey_errors_400_1 PASSED
tests/test_secrets.py::SecretsTests::test_4_PUTKey_errors_400_2 PASSED
tests/test_secrets.py::SecretsTests::test_4_PUTKey_errors_400_3 PASSED
tests/test_secrets.py::SecretsTests::test_4_PUTKey_errors_403 PASSED
tests/test_secrets.py::SecretsTests::test_4_PUTKey_errors_404 PASSED
tests/test_secrets.py::SecretsTests::test_4_PUTKey_errors_405 PASSED
tests/test_secrets.py::SecretsTests::test_4_PUTKey_errors_409 PASSED
tests/test_secrets.py::SecretsTests::test_5_GETKey_errors_403 PASSED
tests/test_secrets.py::SecretsTests::test_5_GETkey_errors_404 PASSED
tests/test_secrets.py::SecretsTests::test_5_GETkey_errors_406 PASSED
tests/test_secrets.py::SecretsTests::test_6_LISTkeys_errors_404_1 PASSED
tests/test_secrets.py::SecretsTests::test_6_LISTkeys_errors_406_1 PASSED
tests/test_secrets.py::SecretsTests::test_7_DELETEKey PASSED
tests/test_secrets.py::SecretsTests::test_7_DELETEKey_errors_403 PASSED
tests/test_secrets.py::SecretsTests::test_7_DELETEKey_errors_404 PASSED
tests/test_secrets.py::SecretsTests::test_7_DELETEKey_errors_405 PASSED
tests/test_secrets.py::SecretsTests::test_8_CREATEcont PASSED
tests/test_secrets.py::SecretsTests::test_8_CREATEcont_erros_403 PASSED
tests/test_secrets.py::SecretsTests::test_8_CREATEcont_erros_404 PASSED
tests/test_secrets.py::SecretsTests::test_8_CREATEcont_erros_405 PASSED
tests/test_secrets.py::SecretsTests::test_8_CREATEcont_erros_409 PASSED
tests/test_secrets.py::SecretsTests::test_8_DESTROYcont PASSED
tests/test_secrets.py::SecretsTests::test_8_DESTROYcont_erros_403 PASSED
tests/test_secrets.py::SecretsTests::test_8_DESTROYcont_erros_404 PASSED
tests/test_secrets.py::SecretsTests::test_8_DESTROYcont_erros_409 PASSED
tests/test_secrets.py::SecretsTests::test_9_0_PUTRawKey PASSED
tests/test_secrets.py::SecretsTests::test_9_1_GETRawKey PASSED
tests/test_secrets.py::SecretsTests::test_9_2_GETKey PASSED
tests/test_server.py::test_args PASSED
tests/test_server.py::test_args_instance PASSED
tests/test_server.py::test_parse_config PASSED
tests/test_server.py::test_parse_config_instance PASSED
tests/test_store.py::EncryptedOverlayTests::test_autogen PASSED
tests/test_store_sqlite.py::SqliteStoreTests::test_0_get_empty PASSED
tests/test_store_sqlite.py::SqliteStoreTests::test_1_list_none PASSED
tests/test_store_sqlite.py::SqliteStoreTests::test_2_set_key PASSED
tests/test_store_sqlite.py::SqliteStoreTests::test_3_list_key PASSED
tests/test_store_sqlite.py::SqliteStoreTests::test_4_multiple_keys PASSED
tests/test_store_sqlite.py::SqliteStoreTests::test_5_set_replace PASSED
tests/test_store_sqlite.py::SqliteStoreTests::test_6_cut_1 PASSED
tests/test_store_sqlite.py::SqliteStoreTests::test_6_cut_2_empty PASSED
tests/test_store_sqlite.py::SqliteStoreTests::test_7_span_1 PASSED
tests/test_store_sqlite.py::SqliteStoreTests::test_7_span_2 PASSED
tests/test_store_sqlite.py::SqliteStoreTests::test_8_cut_span PASSED
============================ 7 failed, 103 passed in 28.41 seconds ============================
```

With error like this:
```python
self = <custodia.client.HTTPUnixConnection object at 0x7fec628abbe0>

    def connect(self):
        s = socket.socket(family=socket.AF_UNIX)
        s.settimeout(self.timeout)
>       s.connect(self.unix_socket)
E       urllib3.exceptions.ProtocolError: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory'))
```

So, custodia server is not ready for processing client's requests. There is a hardcoded delay (1s), it is not enough for me.