### PR TITLE
Allow testing without gssapi and ipaclient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,18 +14,22 @@ addons:
 matrix:
   include:
     - python: 2.7
-      env: TOXENV=py27
+      env: TOXENV=py27-extras
+    - python: 2.7
+      env: TOXENV=py27-noextras
     - python: 3.5
-      env: TOXENV=py35
+      env: TOXENV=py35-extras
     - python: 3.6
-      env: TOXENV=py36
-    - python: 3.5
+      env: TOXENV=py36-extras
+    - python: 3.6
+      env: TOXENV=py36-noextras
+    - python: 3.6
       env: TOXENV=doc
     - python: 3.6
       env: TOXENV=lint
     - python: 2.7
       env: TOXENV=pep8py2
-    - python: 3.5
+    - python: 3.6
       env: TOXENV=pep8py3
 
 before_install:

--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,9 @@ cscope:
 	git ls-files | xargs pycscope
 
 test: clean_socket clean_coverage
-	$(TOX) --skip-missing-interpreters -e py27
-	$(TOX) --skip-missing-interpreters -e py34
-	$(TOX) --skip-missing-interpreters -e py35
-	$(TOX) --skip-missing-interpreters -e py36
+	$(TOX) --skip-missing-interpreters -e py27-extra,py27-noextra
+	$(TOX) --skip-missing-interpreters -e py35-extra,py35-noextra
+	$(TOX) --skip-missing-interpreters -e py36-extra,py36-noextra
 	$(TOX) --skip-missing-interpreters -e doc
 	$(TOX) -e coverage-report
 

--- a/setup.py
+++ b/setup.py
@@ -45,18 +45,18 @@ ipa_requires = [
 ]
 
 # test requirements
-test_requires = [
-    'coverage', 'pytest'
-] + gssapi_requires + ipa_requires
+test_requires = ['coverage', 'pytest']
+test_extras_requires = test_requires + gssapi_requires + ipa_requires
 
 extras_require = {
     'gssapi': gssapi_requires,
     'ipa': ipa_requires,
     'test': test_requires,
+    'test_extras': test_extras_requires,
     'test_docs': ['docutils', 'markdown', 'sphinx-argparse',
                   'sphinxcontrib-spelling'] + ipa_requires,
     'test_pep8': ['flake8', 'flake8-import-order', 'pep8-naming'],
-    'test_pylint': ['pylint'] + test_requires,
+    'test_pylint': ['pylint'] + test_extras_requires,
 }
 
 # backwards compatibility with old setuptools

--- a/tests/test_custodia.py
+++ b/tests/test_custodia.py
@@ -17,7 +17,10 @@ import pytest
 
 import requests.exceptions
 
-import requests_gssapi
+try:
+    import requests_gssapi
+except ImportError:
+    requests_gssapi = None
 
 import six
 
@@ -529,6 +532,10 @@ class CustodiaHTTPSTests(CustodiaTests):
         self.client.del_secret('test/key')
 
 
+@pytest.mark.skipif(
+    requests_gssapi is None,
+    reason="requests_gssapi not available"
+)
 class CustodiaGSSAPITests(unittest.TestCase):
     def test_set_gssapi_auth(self):
         client = CustodiaSimpleClient('http://local.example')

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -8,6 +8,14 @@ import pkg_resources
 from custodia.client import CustodiaHTTPClient
 from custodia.plugin import CSStore, HTTPAuthenticator, HTTPAuthorizer
 
+try:
+    # pylint: disable=unused-import
+    import ipaclient  # noqa: F401
+except ImportError:
+    HAS_IPA = False
+else:
+    HAS_IPA = True
+
 
 class TestCustodiaPlugins(unittest.TestCase):
     project_name = 'custodia'
@@ -17,6 +25,9 @@ class TestCustodiaPlugins(unittest.TestCase):
         for e in pkg_resources.iter_entry_points(group):
             if e.dist.project_name != self.project_name:
                 # only interested in our own entry points
+                continue
+            if not HAS_IPA and e.module_name.startswith('custodia.ipa'):
+                # skip IPA plugins when ipaclient isn't installed
                 continue
             eps.append(e)
         return eps

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.3.1
-envlist = lint,py27,py35,py36,pep8py2,pep8py3,doc,coverage-report
+envlist = lint,py{27,35,36}-{extras,noextras},pep8py2,pep8py3,doc,coverage-report
 skip_missing_interpreters = true
 
 [testenv]
@@ -9,7 +9,8 @@ skip_missing_interpreters = true
 #     CUSTODIAPYTHON = {envpython} -m coverage run --parallel
 # passenv = CUSTODIAPYTHON
 deps =
-    .[test]
+    extras: .[test_extras]
+    noextras: .[test]
 # Makefile and RPM spec set sitepackages=True
 sitepackages = False
 commands =


### PR DESCRIPTION
Make tests pass without presence of requests_gssapi or ipaclient
package.

Signed-off-by: Christian Heimes <cheimes@redhat.com>

Depends on PR #243 