### PR TITLE
Fix Pytest 5 errors

### DIFF
--- a/tests/functional/base.py
+++ b/tests/functional/base.py
@@ -98,8 +98,8 @@ class CustodiaServerRunner(object):
     def custodia_server(self, simple_configuration, request, dev_null):
         # Don't write server messages to stdout unless we are in debug mode
         # pylint: disable=no-member
-        if pytest.config.getoption('debug') or \
-                pytest.config.getoption('verbose'):
+        if request.config.getoption('debug') or \
+                request.config.getoption('verbose'):
             stdout = stderr = None
         else:
             stdout = stderr = dev_null


### PR DESCRIPTION
pytest.config global is deprecated since version 4.1.
https://docs.pytest.org/en/latest/deprecations.html#pytest-config-global

Fixes: https://github.com/latchset/custodia/issues/247