### PR TITLE
Remove invalid test for FreeIPA integration.

### DIFF
--- a/tests/test_ipa.py
+++ b/tests/test_ipa.py
@@ -263,7 +263,6 @@ class TestCustodiaIPA(BaseTest):
             KRB5_CLIENT_KTNAME='/path/to/custodia.keytab',
             KRB5CCNAME='FILE:/path/to/ccache',
         )
-        assert ipaclient.plugins.vault.USER_CACHE_PATH == '/tmp/invalid'
 
 
 class TestCustodiaIPAVault(BaseTest):


### PR DESCRIPTION
Since commit d804f1feeddd31957bc3d88dfb79e9bd119813cb in FreeIPA, where some Custodia modules were removed from FreeIPA, USER_CACHE_PATH is not settable on vault plugin, making an assertion invalid.

This assertion makes FreeIPA tests that use Custodia fail in recent versions.

Signed-off-by: Rafael Guterres Jeffman <rjeffman@redhat.com>